### PR TITLE
Fix the AVHRR reader not masking counts equal to 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
     - NUMPY_VERSION=stable
     - MAIN_CMD='python setup.py'
-    - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff sphinx-argparse graphviz python-graphviz pycoast'
+    - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff sphinx-argparse graphviz python-graphviz pycoast pytest'
     - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
     - SETUP_XVFB=False
     - EVENT_TYPE='push pull_request'


### PR DESCRIPTION
@spruceboy brought this up over email. I looked in to the current version of the reader in Satpy and looks like some new checks have been added. In the future we'll be using Satpy directly, but for now this is an easy fix.