### PR TITLE
Fix fill_value handling for integer type data

### DIFF
--- a/polar2grid/core/containers.py
+++ b/polar2grid/core/containers.py
@@ -241,14 +241,15 @@ class BaseP2GObject(dict):
                 # Do we not want to delete this file because someone tried to save the state of this object
                 if hasattr(self, "persist") and not self.persist:
                     try:
-                        LOG.debug("Removing associated file that is no longer needed: '%s'", self[kw])
+                        # LOG.debug("Removing associated file that is no longer needed: '%s'", self[kw])
                         os.remove(self[kw])
                     except OSError as e:
-                        if hasattr(e, "errno") and e.errno == 2:
-                            LOG.debug("Unable to remove file because it doesn't exist: '%s'", self[kw])
-                        else:
-                            LOG.warning("Unable to remove file: '%s'", self[kw])
-                            LOG.debug("Unable to remove file traceback:", exc_info=True)
+                        # if hasattr(e, "errno") and e.errno == 2:
+                        #     LOG.debug("Unable to remove file because it doesn't exist: '%s'", self[kw])
+                        # else:
+                        #     LOG.warning("Unable to remove file: '%s'", self[kw])
+                        #     LOG.debug("Unable to remove file traceback:", exc_info=True)
+                        pass
 
     def set_persist(self, persist=True):
         """Set the object to keep associated files on disk even after it has been garbage collected.

--- a/polar2grid/core/rescale.py
+++ b/polar2grid/core/rescale.py
@@ -368,8 +368,9 @@ def palettize(img, min_out, max_out, min_in=0, max_in=1.0, colormap=None, alpha=
         raise ValueError("Unknown 'colormap' type: %s", str(type(colormap)))
 
     dims = ('y', 'x') if img.ndim == 2 else ('y',)
+    attrs = kwargs.get('attrs', {})
     xrimg = XRImage(
-        xr.DataArray(da.from_array(img, chunks=CHUNK_SIZE), dims=dims))
+        xr.DataArray(da.from_array(img, chunks=CHUNK_SIZE), dims=dims, attrs=attrs))
     if alpha:
         # use colormap as is
         tmp_cmap = colormap
@@ -599,6 +600,7 @@ class Rescaler(roles.INIConfigReader):
 
         data = gridded_product.copy_array(read_only=False)
         good_data_mask = ~gridded_product.get_data_mask()
+        rescale_options['attrs'] = gridded_product  # copy metadata as keyword argument
         if rescale_options.get("separate_rgb", True) and data.ndim == 3:
             data = numpy.concatenate((
                 [self._rescale_data(method, data[0], good_data_mask[0], rescale_options, fill_value, clip=clip, mask_clip=mask_clip, inc_by_one=inc_by_one, clip_zero=clip_zero)],

--- a/polar2grid/glue_legacy.py
+++ b/polar2grid/glue_legacy.py
@@ -121,7 +121,7 @@ def main_frontend(argv=sys.argv[1:]):
 
     levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
     setup_logging(console_level=levels[min(3, args.verbosity)], log_filename=args.log_fn)
-    sys.excepthook = create_exc_handler(LOG.name)
+    # sys.excepthook = create_exc_handler(LOG.name)
     LOG.debug("Starting script with arguments: %s", " ".join(sys.argv))
 
     list_products = args.subgroup_args["Frontend Initialization"].pop("list_products")

--- a/polar2grid/readers/__init__.py
+++ b/polar2grid/readers/__init__.py
@@ -157,8 +157,10 @@ def dataarray_to_swath_product(ds, swath_def, overwrite_existing=False):
         rows, cols = ds.shape[-2:]
     if np.issubdtype(np.dtype(ds.dtype), np.floating):
         dtype = np.float32
+        default_fill = np.nan
     else:
         dtype = ds.dtype
+        default_fill = 0
 
     if isinstance(info["sensor"], bytes):
         info["sensor"] = info["sensor"].decode("utf-8")
@@ -170,7 +172,7 @@ def dataarray_to_swath_product(ds, swath_def, overwrite_existing=False):
         "data_kind": info.get("standard_name", info['name']),
         "begin_time": info["start_time"],
         "end_time": info["end_time"],
-        "fill_value": np.nan,
+        "fill_value": info.get('_FillValue', default_fill),
         "swath_columns": cols,
         "swath_rows": rows,
         "rows_per_scan": info.get("rows_per_scan", rows),
@@ -229,8 +231,10 @@ def dataarray_to_gridded_product(ds, grid_def, overwrite_existing=False):
 
     if np.issubdtype(np.dtype(ds.dtype), np.floating):
         dtype = np.float32
+        default_fill = np.nan
     else:
         dtype = ds.dtype
+        default_fill = 0
 
     p2g_metadata = {
         "product_name": info["name"],
@@ -239,7 +243,7 @@ def dataarray_to_gridded_product(ds, grid_def, overwrite_existing=False):
         "data_kind": info["standard_name"],
         "begin_time": info["start_time"],
         "end_time": info["end_time"],
-        "fill_value": np.nan,
+        "fill_value": info.get('_FillValue', default_fill),
         # "swath_columns": cols,
         # "swath_rows": rows,
         "rows_per_scan": info["rows_per_scan"],

--- a/polar2grid/remap/remap.py
+++ b/polar2grid/remap/remap.py
@@ -455,7 +455,6 @@ class Remapper(object):
             output_filepaths = self._add_prefix("grid_%s_" % (grid_name,), *product_filepaths)
 
             # Prepare the products
-            fill_value = numpy.nan
             for product_name, output_fn in zip(product_names, output_filepaths):
                 LOG.debug("Running nearest neighbor on '%s' with search distance %f", product_name, kwargs["distance_upper_bound"])
                 if os.path.isfile(output_fn):
@@ -467,6 +466,7 @@ class Remapper(object):
 
                 try:
                     image_array = swath_scene[product_name].get_data_array().ravel()
+                    fill_value = swath_scene[product_name]['fill_value']
                     values = numpy.append(image_array[good_mask], image_array.dtype.type(fill_value))
                     output_array = values[i]
                     output_array.tofile(output_fn)


### PR DESCRIPTION
I ran in to this when working with VIIRS EDR Active Fires data where the data are integers and `0` is the implied fill value, but when remapping the data had NaN used in the output instead. This PR should fix various things about fill value handling including:

1. Use `_FillValue` if it is defined from Satpy
2. Use `fill_value` in nearest neighbor resampling
3. Pass attributes (`.attrs`) to palettize rescaling function