### PR TITLE
Add satellite name normalization for NOAA-NN and SNPP satellites

### DIFF
--- a/polar2grid/crefl/crefl2swath.py
+++ b/polar2grid/crefl/crefl2swath.py
@@ -165,6 +165,7 @@ import polar2grid.viirs.io as viirs_io
 import polar2grid.viirs.swath as viirs_module
 from polar2grid.core import containers, roles
 from polar2grid.core.frontend_utils import ProductDict, GeoPairDict
+from polar2grid.readers import normalize_satellite_name
 
 LOG = logging.getLogger(__name__)
 
@@ -256,7 +257,7 @@ class VIIRSCreflReader(modis_guidebook.HDFReader):
         # CREFLM_npp_d20141103_t1758468_e1800112.hdf
         fn = os.path.splitext(self.filename)[0]
         parts = fn.split("_")
-        self.satellite = parts[1].lower()
+        self.satellite = normalize_satellite_name(parts[1])
         self.instrument = "viirs"
 
         # Parse out the datetime, making sure to add the microseconds and set the timezone to UTC

--- a/polar2grid/readers/__init__.py
+++ b/polar2grid/readers/__init__.py
@@ -53,6 +53,19 @@ from polar2grid.core import containers, roles
 LOG = logging.getLogger(__name__)
 
 
+def normalize_satellite_name(input_sat):
+    """Normalize satellite names for Polar2Grid (not Geo2Grid)."""
+    input_sat = input_sat.lower().replace('-', '').replace('_', '')
+    if 'suomi' in input_sat or input_sat == 'snpp':
+        return 'npp'
+
+    if 'jpss' in input_sat:
+        # map JPSS-1 to NOAA-20 and so on
+        return 'noaa' + ['20', '21', '22'][int(input_sat[4:]) - 1]
+    return input_sat
+
+
+
 def area_to_swath_def(area, chunks=4096, overwrite_existing=False):
     if hasattr(area, 'lons') and area.lons is not None:
         lons = area.lons
@@ -167,7 +180,7 @@ def dataarray_to_swath_product(ds, swath_def, overwrite_existing=False):
 
     p2g_metadata = {
         "product_name": info["name"],
-        "satellite": info["platform_name"].lower(),
+        "satellite": normalize_satellite_name(info["platform_name"]),
         "instrument": info["sensor"].lower() if isinstance(info["sensor"], str) else list(info["sensor"])[0].lower(),
         "data_kind": info.get("standard_name", info['name']),
         "begin_time": info["start_time"],
@@ -238,7 +251,7 @@ def dataarray_to_gridded_product(ds, grid_def, overwrite_existing=False):
 
     p2g_metadata = {
         "product_name": info["name"],
-        "satellite": info["platform_name"].lower(),
+        "satellite": normalize_satellite_name(info["platform_name"]),
         "instrument": info["sensor"].lower() if isinstance(info["sensor"], str) else list(info["sensor"])[0].lower(),
         "data_kind": info["standard_name"],
         "begin_time": info["start_time"],

--- a/polar2grid/viirs/io.py
+++ b/polar2grid/viirs/io.py
@@ -50,6 +50,7 @@ import os
 from polar2grid.core.frontend_utils import BaseMultiFileReader, BaseFileReader
 from polar2grid.viirs import guidebook
 from polar2grid.viirs.guidebook import K_MOONILLUM
+from polar2grid.readers import normalize_satellite_name
 
 LOG = logging.getLogger(__name__)
 ORBIT_TRANSITION_THRESHOLD = timedelta(seconds=10)
@@ -125,11 +126,8 @@ class VIIRSSDRReader(BaseFileReader):
         """
         super(VIIRSSDRReader, self).__init__(file_handle, file_type_info)
 
-        self.satellite = self[guidebook.K_SATELLITE].lower()
-        if self.satellite == 'j01':
-            self.satellite = 'noaa20'
-        elif self.satellite == 'j02':
-            self.satellite = 'noaa21'
+        self.satellite = self[guidebook.K_SATELLITE]
+        self.satellite = normalize_satellite_name(self.satellite)
         self.instrument = "viirs"
 
         # begin time


### PR DESCRIPTION
The various VIIRS readers (crefl, viirs l1b, viir sdr) produce different names for the satellite/platform name that goes in the resulting output filename. This PR normalizes all of them to use "npp" for Suomi-NPP and "noaa20" for NOAA-20/JPSS-1. It should be relatively flexible and work with future noaa satellites following this naming structure.