### PR TITLE
Update fornav templates to work with C++11

### DIFF
--- a/polar2grid/remap/_fornav_templates.cpp
+++ b/polar2grid/remap/_fornav_templates.cpp
@@ -2,18 +2,17 @@
 #include <stddef.h>
 #include "math.h"
 #include "numpy/arrayobject.h"
+#include "numpy/npy_math.h"
 #include "_fornav_templates.h"
 
-inline bool safe_isnan(npy_int8 val) {
-    return false;
+template<typename IMAGE_TYPE> int __isnan(IMAGE_TYPE x) {
+    // Return numpy's isnan for normal float arguments (see __isnan below for ints)
+    return npy_isnan(x);
 }
 
-inline bool safe_isnan(npy_float32 val) {
-    return isnan(val);
-}
-
-inline bool safe_isnan(npy_float64 val) {
-    return isnan(val);
+int __isnan(npy_int8 x) {
+    // Sometimes input data may be integers, need to be able to handle those similarly
+    return 0;
 }
 
 int initialize_weight(size_t chan_count, unsigned int weight_count, weight_type weight_min, weight_type weight_distance_max,
@@ -235,7 +234,7 @@ int compute_ewa(size_t chan_count, int maximum_weight_mode,
       u0 = uimg[swath_offset];
       v0 = vimg[swath_offset];
 
-      if (u0 < 0.0 || v0 < 0.0 || safe_isnan(u0) || safe_isnan(v0)) {
+      if (u0 < 0.0 || v0 < 0.0 || __isnan(u0) || __isnan(v0)) {
         continue;
       }
 
@@ -284,14 +283,14 @@ int compute_ewa(size_t chan_count, int maximum_weight_mode,
                 if (maximum_weight_mode) {
                   if (weight > grid_weights[chan][grid_offset]) {
                     ((grid_weights[chan])[grid_offset]) = weight;
-                    if ((this_val == img_fill) || (safe_isnan(this_val))) {
-                      ((grid_accums[chan])[grid_offset]) = (accum_type)NAN;
+                    if ((this_val == img_fill) || (__isnan(this_val))) {
+                      ((grid_accums[chan])[grid_offset]) = (accum_type)NPY_NANF;
                     } else {
                       ((grid_accums[chan])[grid_offset]) = (accum_type)this_val;
                     }
                   }
                 } else {
-                  if ((this_val != img_fill) && !(safe_isnan(this_val))) {
+                  if ((this_val != img_fill) && !(__isnan(this_val))) {
                     ((grid_weights[chan])[grid_offset]) += weight;
                     ((grid_accums[chan])[grid_offset]) += (accum_type)this_val * weight;
                   }
@@ -410,18 +409,18 @@ unsigned int write_grid_image(GRID_TYPE *output_image, GRID_TYPE fill, size_t gr
        i++, grid_accum++, grid_weights++, output_image++) {
     // Calculate the elliptical weighted average value for each cell (float -> not-float needs rounding)
     // The fill value for the weight and accumulation arrays is static at NaN
-    if (*grid_weights < weight_sum_min or safe_isnan(*grid_accum)) {
-      chanf = (accum_type)NAN;
+    if (*grid_weights < weight_sum_min || __isnan(*grid_accum)) {
+      chanf = (accum_type)NPY_NANF;
     } else if (maximum_weight_mode) {
       // keep the current value
       chanf = *grid_accum;
-    } else if (chanf >= 0.0) {
+    } else if (*grid_accum >= 0.0) {
       chanf = *grid_accum / *grid_weights + get_rounding(output_image);
     } else {
       chanf = *grid_accum / *grid_weights - get_rounding(output_image);
     }
 
-    if (safe_isnan(chanf)) {
+    if (__isnan(chanf)) {
       *output_image = (GRID_TYPE)fill;
     } else {
       valid_count++;

--- a/polar2grid/remap/_fornav_templates.cpp
+++ b/polar2grid/remap/_fornav_templates.cpp
@@ -4,15 +4,15 @@
 #include "numpy/arrayobject.h"
 #include "_fornav_templates.h"
 
-bool safe_isnan(npy_int8 val) {
+inline bool safe_isnan(npy_int8 val) {
     return false;
 }
 
-bool safe_isnan(npy_float32 val) {
+inline bool safe_isnan(npy_float32 val) {
     return isnan(val);
 }
 
-bool safe_isnan(npy_float64 val) {
+inline bool safe_isnan(npy_float64 val) {
     return isnan(val);
 }
 


### PR DESCRIPTION
Linux on Travis is now using gcc 5.4 which is using C++11 by default. This is causing failures for fornavs compilation because there are cases where I pass an integer to `isnan` (a builtin function). In C99 this is a macro and returned False for integers, in C++11 this is a real function that only has signatures for floats/doubles. This is my simple fix.

@rayg-ssec It'd be great if you could sanity check this given my limited C++ knowledge.