### PR TITLE
Add --radius-of-influence flag for nearest neighbor resampling

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,7 +1,19 @@
 Release Notes
 =============
 
-Version 2.2.1 (unreleased)
+Version 2.3.0 (unreleased)
+--------------------------
+
+* Add FY-3C VIRR reader
+* Add MERSI-2 reader
+* Add VIIRS EDR Flood reader
+* Add VIIRS EDR Active Fire reader
+* Add "overlay.sh" script for overlaying active fire products
+* Add '--borders-width' flag to "add_coastlines.sh"
+* Fix AVHRR reader not masking bad 0 values
+* Fix MIRS reader not using valid range properly
+
+Version 2.2.1 (2018-04-27)
 --------------------------
 
 * Fix CREFL reader not reading negative reflectances

--- a/NEWS_GEO2GRID.rst
+++ b/NEWS_GEO2GRID.rst
@@ -1,7 +1,14 @@
 Release Notes
 =============
 
-Version 1.0.0 (unreleased)
+Version 1.0.1 (unreleased)
+--------------------------
+
+* Fix resampling freezing when output grid was larger than 1024x1024
+* Fix crash when certain RGBs were created with '--ll-bbox'
+* Add missing '--radius-of-influence' flag for nearest neighbor resampling
+
+Version 1.0.0 (2019-03-01)
 --------------------------
 
 * New Geo2Grid Package!

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -53,7 +53,7 @@ What's New?
 
     .. include:: NEWS.rst
         :start-line: 6
-        :end-line: 17
+        :end-line: 14
 
     For more details on what's new in this version and past versions see the
     `Release Notes <https://raw.githubusercontent.com/ssec/polar2grid/master/NEWS.rst>`_
@@ -65,7 +65,7 @@ What's New?
 
     .. include:: NEWS_GEO2GRID.rst
         :start-line: 6
-        :end-line: 17
+        :end-line: 9
 
     For more details on what's new in this version and past versions see the
     `Release Notes <https://raw.githubusercontent.com/ssec/polar2grid/master/NEWS_GEO2GRID.rst>`_

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -137,6 +137,14 @@ def add_resample_argument_groups(parser):
                               'bounds (lon_min lat_min lon_max lat_max). '
                               'Coordinates must be valid in the source data '
                               'projection.')
+
+    # nearest neighbor resampling
+    group_1.add_argument('--radius-of-influence', default=None,
+                         help='Specify radius to search for valid input '
+                              'pixels for nearest neighbor resampling. '
+                              'Value is in projection units (typically meters).'
+                              'By default this will be determined by input '
+                              'pixel size.')
     return tuple([group_1])
 
 


### PR DESCRIPTION
Closes #185.

This is for Geo2Grid 1.0.1. Some users needed to change the radius of influence for nearest neighbor resampling and I had forgotten to add this as an option.