### PR TITLE
Add ability to native resample to lower resolution grids

### DIFF
--- a/NEWS_GEO2GRID.rst
+++ b/NEWS_GEO2GRID.rst
@@ -7,6 +7,8 @@ Version 1.0.1 (unreleased)
 * Fix resampling freezing when output grid was larger than 1024x1024
 * Fix crash when certain RGBs were created with '--ll-bbox'
 * Add missing '--radius-of-influence' flag for nearest neighbor resampling
+* Add ability to native resample to lower resolution grids
+* Add 'goes_east_Xkm' and 'goes_west_Xkm' grids for easier lower resolution resampling
 
 Version 1.0.0 (2019-03-01)
 --------------------------

--- a/build_environment.yml
+++ b/build_environment.yml
@@ -39,4 +39,4 @@ dependencies:
   - xarray
   - scipy
   - pip:
-    - git+https://github.com/pytroll/satpy.git@master
+    - git+https://github.com/djhoese/satpy.git@bugfix-abi-extents

--- a/doc/source/grids.rst
+++ b/doc/source/grids.rst
@@ -219,3 +219,51 @@ Equirectangular Fit
 :Y Pixel Size: 250 meters
 :X Origin: None
 :Y Origin: None
+
+GOES-East 1km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_east_1km
+:Description: 1 kilometer resolution GOES-16 Full Disk
+
+GOES-East 4km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_east_4km
+:Description: 4 kilometer resolution GOES-16 Full Disk
+
+GOES-East 8km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_east_8km
+:Description: 8 kilometer resolution GOES-16 Full Disk
+
+GOES-East 10km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_east_10km
+:Description: 10 kilometer resolution GOES-16 Full Disk
+
+GOES-West 1km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_west_1km
+:Description: 1 kilometer resolution GOES-17 Full Disk
+
+GOES-West 4km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_west_4km
+:Description: 4 kilometer resolution GOES-17 Full Disk
+
+GOES-West 8km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_west_8km
+:Description: 8 kilometer resolution GOES-17 Full Disk
+
+GOES-West 10km
+^^^^^^^^^^^^^
+
+:Grid Name: goes_west_10km
+:Description: 10 kilometer resolution GOES-17 Full Disk

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -65,7 +65,7 @@ What's New?
 
     .. include:: NEWS_GEO2GRID.rst
         :start-line: 6
-        :end-line: 9
+        :end-line: 11
 
     For more details on what's new in this version and past versions see the
     `Release Notes <https://raw.githubusercontent.com/ssec/polar2grid/master/NEWS_GEO2GRID.rst>`_

--- a/polar2grid/core/containers.py
+++ b/polar2grid/core/containers.py
@@ -627,18 +627,18 @@ class GridDefinition(GeographicDefinition):
 
     @property
     def xy_lowerright(self):
-        y_ll = self["origin_y"] + self["cell_height"] * self["height"]
-        x_ll = self["origin_x"] + self["cell_width"] * self["width"]
+        y_ll = self["origin_y"] + self["cell_height"] * (self["height"] - 1)
+        x_ll = self["origin_x"] + self["cell_width"] * (self["width"] - 1)
         return x_ll, y_ll
 
     @property
     def xy_lowerleft(self):
-        y_ll = self["origin_y"] + self["cell_height"] * self["height"]
+        y_ll = self["origin_y"] + self["cell_height"] * (self["height"] - 1)
         return self["origin_x"], y_ll
 
     @property
     def xy_upperright(self):
-        x_ll = self["origin_x"] + self["cell_width"] * self["width"]
+        x_ll = self["origin_x"] + self["cell_width"] * (self["width"] - 1)
         return x_ll, self["origin_y"]
 
     @property
@@ -731,6 +731,7 @@ class GridDefinition(GeographicDefinition):
     @property
     def ll_extent(self):
         xy_ll = self.xy_lowerleft
+        # NOTE: cell_height is negative
         return xy_ll[0] - self["cell_width"]/2., xy_ll[1] + self["cell_height"]/2.
 
     @property
@@ -740,6 +741,7 @@ class GridDefinition(GeographicDefinition):
     @property
     def ur_extent(self):
         xy_ur = self.xy_upperright
+        # NOTE: cell_height is negative
         return xy_ur[0] + self["cell_width"]/2., xy_ur[1] - self["cell_height"]/2.
 
     @property

--- a/polar2grid/grids/grids.conf
+++ b/polar2grid/grids/grids.conf
@@ -28,14 +28,24 @@ polar_russia,           proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +
 polar_alaska,           proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          400,         -400,               None,              None
 polar_alaska_300,       proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          300,         -300,               None,              None
 polar_alaska_750,       proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          750,         -750,               None,              None
-polar_alaska_1km,       proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,         1000,         -1000,              None,              None
-merc_conus_300,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          300,          -300,              None,              None
-merc_conus_750,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          750,          -750,              None,              None
-merc_conus_1km,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,         1000,         -1000,              None,              None
-merc_pacific_300,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          300,          -300,              None,              None
-merc_pacific_750,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          750,          -750,              None,              None
-merc_pacific_1km,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,         1000,         -1000,              None,              None
-goesr_test_300,         proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-89.5 +units=m +sweep=x +h=35786023.0 +no_defs, None,    None,          300,          -300,              None,              None
+polar_alaska_1km,       proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,         1000,        -1000,               None,              None
+merc_conus_300,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          300,         -300,               None,              None
+merc_conus_750,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          750,         -750,               None,              None
+merc_conus_1km,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,         1000,        -1000,               None,              None
+merc_pacific_300,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          300,         -300,               None,              None
+merc_pacific_750,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          750,         -750,               None,              None
+merc_pacific_1km,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,         1000,        -1000,               None,              None
+# GOES Grids
+goesr_test_300,         proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-89.5 +units=m +sweep=x +h=35786023.0,     None,    None,          300,         -300,               None,              None
+# Static GOES Grids - Nominal upper-left extent (outer edge) is (-5434894.885056, 5434894.885056)
+goes_east_1km,          proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-75.0 +units=m +sweep=x +h=35786023.0,    10848,   10848,  1002.008644, -1002.008644,    -5434393.880734,    5434393.880734
+goes_east_4km,          proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-75.0 +units=m +sweep=x +h=35786023.0,     2712,    2712,  4008.034576, -4008.034576,    -5432890.867768,    5432890.867768
+goes_east_8km,          proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-75.0 +units=m +sweep=x +h=35786023.0,     1356,    1356,  8016.069152, -8016.069152, -5430886.8504800005, 5430886.8504800005
+goes_east_10km,         proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-75.0 +units=m +sweep=x +h=35786023.0,     1085,    1085, 10018.239419458065, -10018.239419458065, -5429885.765346271, 5429885.765346271
+goes_west_1km,          proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-137.0 +units=m +sweep=x +h=35786023.0,   10848,   10848,  1002.008644, -1002.008644,    -5434393.880734,    5434393.880734
+goes_west_4km,          proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-137.0 +units=m +sweep=x +h=35786023.0,    2712,    2712,  4008.034576, -4008.034576,    -5432890.867768,    5432890.867768
+goes_west_8km,          proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-137.0 +units=m +sweep=x +h=35786023.0,    1356,    1356,  8016.069152, -8016.069152, -5430886.8504800005, 5430886.8504800005
+goes_west_10km,         proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-137.0 +units=m +sweep=x +h=35786023.0,    1085,    1085, 10018.239419458065, -10018.239419458065, -5429885.765346271, 5429885.765346271
 # Static Grids
 dwd_germany,            proj4, +proj=stere +a=6370000 +b=6370000 +lat_0=90 +lat_ts=60 +lon_0=10 +units=m +no_defs,        3000,    4000,          400,         -400,            -2.0deg,           56.0deg
 australia,              proj4, +proj=merc +a=6378137 +b=6378137 +lat_0=-30 +lon_0=140 +units=m +no_defs,                  7700,    7700,       1015.9,      -1015.9,           105.0deg,            5.0deg


### PR DESCRIPTION
This PR adds one work around for #187.

This adds new GOES-based grids to the default builtin grids:

* goes_east_1km
* goes_east_4km
* goes_east_8km
* goes_east_10km
* goes_west_1km
* goes_west_4km
* goes_west_8km
* goes_west_10km

It also allows users to use `native` resampling by default if Geo2Grid detects that a grid is "native" compatible. This should not really change behavior for anyone unless they were already attempting to do what #187 talks about: resampling to a lower resolution version of the GOES grids. Note these new grids are only the full disk versions of these grids. I'm considering this a bug fix because it should have been possible for users to do this already.