### PR TITLE
Set default grid_coverage for VIIRS Active Fires to 0

### DIFF
--- a/polar2grid/readers/viirs_edr_active_fires.py
+++ b/polar2grid/readers/viirs_edr_active_fires.py
@@ -71,7 +71,7 @@ def add_frontend_argument_groups(parser):
     """
     from polar2grid.core.script_utils import ExtendAction
     # Set defaults for other components that may be used in polar2grid processing
-    parser.set_defaults(remap_method='nearest')
+    parser.set_defaults(remap_method='nearest', grid_coverage=0)
 
     # Use the append_const action to handle adding products to the list
     group_title = "Frontend Initialization"

--- a/polar2grid/remap/remap.py
+++ b/polar2grid/remap/remap.py
@@ -546,7 +546,7 @@ def add_remap_argument_groups(parser):
                        help="Remapping algorithm to use")
     group.add_argument('--swath-usage', dest="swath_usage", default=0, type=float,
                        help="Fraction of swath that must be used to continue remapping/processing (default 0)")
-    group.add_argument('--grid-coverage', dest="grid_coverage", default=0.1, type=float,
+    group.add_argument('--grid-coverage', dest="grid_coverage", default=SUPPRESS, type=float,
                        help="Fraction of grid that must be covered with valid data to continue processing (default 0.1)")
     group.add_argument('--fornav-D', dest='fornav_D', default=SUPPRESS, type=float,
                        help="Specify the -D option for fornav")


### PR DESCRIPTION
See #197 for details.

This changes `--grid-coverage` in to a parameter that can be set from readers, similar to `--fornav-d` and `--fornav-D`. This sets it to 0 for the viirs_edr_active_fires reader.