### PR TITLE
Fix VIIRS EDR Active Fires confidence_pct rescaling configuration

### DIFF
--- a/polar2grid/core/rescale_configs/rescale.ini
+++ b/polar2grid/core/rescale_configs/rescale.ini
@@ -590,6 +590,14 @@ min_in=7
 max_in=9
 alpha=True
 
+[rescale:confidence_pct]
+product_name=confidence_pct
+method=palettize
+colormap=ylorrd
+min_in=0
+max_in=100
+alpha=True
+
 ; VIIRS EDR Flood
 [rescale:water_detection]
 product_name=WaterDetection

--- a/polar2grid/core/rescale_configs/rescale.ini
+++ b/polar2grid/core/rescale_configs/rescale.ini
@@ -598,6 +598,15 @@ min_in=0
 max_in=100
 alpha=True
 
+[rescale:fire_power]
+product_name=power
+reader=viirs_edr_active_fires
+method=palettize
+colormap=ylorrd
+min_in=0
+max_in=250
+alpha=True
+
 ; VIIRS EDR Flood
 [rescale:water_detection]
 product_name=WaterDetection


### PR DESCRIPTION
As mentioned in #197, it wasn't possible to create a colorized image of `confidence_pct` from the VIIRS EDR active fire reader in the latest polar2grid 2.3.0 alpha. This was because I forgot to configure it in the rescaling.

We should also configure something for `power`, @kathys is looking in to good values for this.