### PR TITLE
Fix rescaling configuration for some active fires variables

### DIFF
--- a/polar2grid/core/rescale_configs/rescale.ini
+++ b/polar2grid/core/rescale_configs/rescale.ini
@@ -594,7 +594,7 @@ alpha=True
 product_name=confidence_pct
 method=palettize
 colormap=ylorrd
-min_in=0
+min_in=1
 max_in=100
 alpha=True
 

--- a/polar2grid/readers/__init__.py
+++ b/polar2grid/readers/__init__.py
@@ -71,7 +71,6 @@ def normalize_satellite_name(input_sat):
     return input_sat
 
 
-
 def area_to_swath_def(area, chunks=4096, overwrite_existing=False):
     if hasattr(area, 'lons') and area.lons is not None:
         lons = area.lons
@@ -316,6 +315,7 @@ def convert_satpy_to_p2g_swath(frontend, scene, convert_area_defs=True):
             swath_def.setdefault("rows_per_scan", ds.attrs.get("rows_per_scan", def_rps))
 
         for swath_product in dataarray_to_swath_product(ds, swath_def, overwrite_existing=overwrite_existing):
+            swath_product.setdefault('reader', frontend.reader)
             p2g_scene[swath_product["product_name"]] = swath_product
 
     return p2g_scene
@@ -332,6 +332,7 @@ def convert_satpy_to_p2g_gridded(frontend, scene):
             areas[ds.attrs["area"].name] = grid_def = area_to_grid_definition(ds.attrs["area"],
                                                                              overwrite_existing=overwrite_existing)
         gridded_product = dataarray_to_gridded_product(ds, grid_def, overwrite_existing=overwrite_existing)
+        gridded_product.setdefault('reader', frontend.reader)
         p2g_scene[gridded_product["name"]] = gridded_product
 
     return p2g_scene


### PR DESCRIPTION
Pointed out in our meeting today:

1. `confidence_pct` being from 0-100% results in `0` values (the most common value) being yellow which is different than `confidence_cat` which is transparent for non-fire pixels.
2. Fire `power` was not being scaled properly because I used the `reader` parameter in the rescaling configuration. The Satpy reader wrapping code was not assigning the `reader` in product metadata so this information was never getting to rescaling.

This PR should fix both of these cases.