### PR TITLE
Fix VIIRS Active Fires creating non-standard geotiff files

### DIFF
--- a/polar2grid/core/rescale_configs/rescale.ini
+++ b/polar2grid/core/rescale_configs/rescale.ini
@@ -584,7 +584,7 @@ max_in=32
 ; VIIRS EDR Active Fires
 [rescale:confidence_cat]
 product_name=confidence_cat
-method=palettize
+method=colorize
 colormap=ylorrd
 min_in=7
 max_in=9
@@ -592,16 +592,16 @@ alpha=True
 
 [rescale:confidence_pct]
 product_name=confidence_pct
-method=palettize
+method=colorize
 colormap=ylorrd
-min_in=1
+min_in=0
 max_in=100
 alpha=True
 
 [rescale:fire_power]
 product_name=power
 reader=viirs_edr_active_fires
-method=palettize
+method=colorize
 colormap=ylorrd
 min_in=0
 max_in=250

--- a/polar2grid/readers/__init__.py
+++ b/polar2grid/readers/__init__.py
@@ -192,6 +192,7 @@ def dataarray_to_swath_product(ds, swath_def, overwrite_existing=False):
         "begin_time": info["start_time"],
         "end_time": info["end_time"],
         "fill_value": default_fill,
+        "_FillValue": default_fill,  # might be used by satpy later
         "swath_columns": cols,
         "swath_rows": rows,
         "rows_per_scan": info.get("rows_per_scan", rows),


### PR DESCRIPTION
This one should actually fix #205 

In summary, I was making an LA geotiff where the L band had a color table added to it. The assumption was that the color table would color the L pixels and the A band would be able to tell us the transparency. That was not true. These are, as far as what I wanted them to look like, invalid geotiffs and are not recognized by most image viewers.

The solution is to generate RGBA images where each pixel has the colortable already applied to it. The Alpha band determines transparency and invalid pixels.

This PR also depends on some of the recent fixes in Satpy for the `power` dataset and how it has its `_FillValue` set.