### PR TITLE
Fix MERSI-2 natural_color scaling and add false_color composite

### DIFF
--- a/etc/composites/mersi-2.yaml
+++ b/etc/composites/mersi-2.yaml
@@ -1,0 +1,17 @@
+sensor_name: visir/mersi-2
+
+composites:
+  false_color:
+    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
+    prerequisites:
+      - name: '7'
+        modifiers: [sunz_corrected]
+      - name: '15'
+        modifiers: [sunz_corrected]
+      - name: '3'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: '4'
+        modifiers: [sunz_corrected]
+    standard_name: false_color
+    high_resolution_band: green

--- a/polar2grid/core/rescale_configs/rescale.ini
+++ b/polar2grid/core/rescale_configs/rescale.ini
@@ -174,6 +174,13 @@ min_in=-1.0
 max_in=110.1
 separate_rgb=False
 
+[rescale:default_natural_color]
+data_kind=natural_color
+method=lookup
+min_in=-1.0
+max_in=110.1
+separate_rgb=False
+
 [rescale:default_rain_rate]
 data_kind=rain_rate
 method=linear


### PR DESCRIPTION
Closes #214

## Natural Color

![fy3d_mersi-2_natural_color_20190312_182739_wgs84_fit](https://user-images.githubusercontent.com/1828519/67034522-71d90f00-f0dd-11e9-9b7c-c479b4bcf341.png)

## False Color

![fy3d_mersi-2_false_color_20190312_182739_wgs84_fit](https://user-images.githubusercontent.com/1828519/67034523-71d90f00-f0dd-11e9-8c83-f103b4dbf495.png)
