### PR TITLE
Fix modified datasets causing duplicate cached files on disk

### DIFF
--- a/polar2grid/readers/__init__.py
+++ b/polar2grid/readers/__init__.py
@@ -204,7 +204,10 @@ def dataarray_to_swath_product(ds, swath_def, overwrite_existing=False):
     info.update(p2g_metadata)
 
     if channels == 1:
-        filename = info["name"] + ".dat"
+        filename = "-".join([info['name'], str(info['calibration']), str(info['resolution'])])
+        if info.get('modifiers'):
+            filename += '-' + '_'.join(info['modifiers'])
+        filename = filename + ".dat"
         info["swath_data"] = filename
         if os.path.isfile(filename):
             if not overwrite_existing:
@@ -394,7 +397,7 @@ class ReaderWrapper(roles.FrontendRole):
         kwargs.pop("overwrite_existing")
         kwargs.pop("exit_on_error")
         kwargs.pop("keep_intermediate")
-        self.scene.load(products, **kwargs)
+        self.scene.load(products, generate=False, **kwargs)
         self.wishlist = self.scene.wishlist
         self.missing_datasets = self.scene.missing_datasets
 


### PR DESCRIPTION
Closes #207 

This was a simple fix for a very complicated problem...

## The Problem

Polar2Grid uses a product's *name* (and only the name) to uniquely identify that product. Satpy uses name, resolution, calibration, and optional modifiers (among some other things). In certain cases, usually when composites need to be made with rayleigh correction or other modifiers applied, the "raw" band needs to exist along side the "modified" band at the same time. Polar2Grid internals do not currently handle this case since it would involve using more than just the name.

## The Solution

By passing `generate=False` to the Satpy Scene's `load` method, P2G tells it not to do any modifications/corrections or try to generate any composites until *after* resampling. After resampling we shouldn't need any of these modified datasets so there shouldn't be any conflicts/overlap.

Since Polar2Grid 3.0 will be directly using Satpy and Satpy's storing of the datasets, we won't need to worry about this.