### PR TITLE
Fix race condition when deleting multiple gridded scenes

### DIFF
--- a/polar2grid/compositors/rgb.py
+++ b/polar2grid/compositors/rgb.py
@@ -237,7 +237,9 @@ class RGBCompositor(roles.CompositorRole):
         if fill_value is None:
             fill_value = gridded_scene[self.composite_products[0]]["fill_value"]
 
-        fn = self.composite_name + ".dat"
+        base_product = gridded_scene[self.composite_products[0]]
+        grid_name = base_product['grid_definition']['grid_name']
+        fn = "grid_{}_{}.dat".format(grid_name, self.composite_name)
 
         try:
             comp_data = self.joined_array(gridded_scene, self.composite_products)
@@ -246,7 +248,6 @@ class RGBCompositor(roles.CompositorRole):
                 comp_data[:, self.shared_mask(gridded_scene, self.composite_products)] = fill_value
 
             comp_data.tofile(fn)
-            base_product = gridded_scene[self.composite_products[0]]
             gridded_scene[self.composite_name] = self._create_gridded_product(self.composite_name, fn, base_product=base_product,
                                                                               data_kind=self.composite_data_kind)
         except (ValueError, KeyError):
@@ -320,10 +321,12 @@ class TrueColorCompositor(RGBCompositor):
         if fill_value is None:
             fill_value = gridded_scene[red_product]["fill_value"]
 
-        fn = self.composite_name + ".dat"
+        all_products = [red_product, green_product, blue_product]
+        base_product = gridded_scene[all_products[0]]
+        grid_name = base_product['grid_definition']['grid_name']
+        fn = "grid_{}_{}.dat".format(grid_name, self.composite_name)
 
         try:
-            all_products = [red_product, green_product, blue_product]
             sharp_red_product = self._get_first_available_product(gridded_scene, self.hires_products)
             if sharp_red_product and self.sharpen_rgb:
                 all_products.append(sharp_red_product)
@@ -342,7 +345,6 @@ class TrueColorCompositor(RGBCompositor):
             LOG.debug("True color array has shape %r", comp_data.shape)
             LOG.info("Saving true color image to filename '%s'", fn)
             comp_data.tofile(fn)
-            base_product = gridded_scene[all_products[0]]
             gridded_scene[self.composite_name] = self._create_gridded_product(self.composite_name, fn,
                                                                               base_product=base_product,
                                                                               data_kind=self.composite_data_kind)
@@ -381,7 +383,10 @@ class FalseColorCompositor(TrueColorCompositor):
         if fill_value is None:
             fill_value = gridded_scene[red_product]["fill_value"]
 
-        fn = self.composite_name + ".dat"
+        all_products = [red_product, green_product, blue_product]
+        base_product = gridded_scene[all_products[0]]
+        grid_name = base_product['grid_definition']['grid_name']
+        fn = "grid_{}_{}.dat".format(grid_name, self.composite_name)
 
         try:
             all_products = [red_product, green_product, blue_product]
@@ -403,7 +408,6 @@ class FalseColorCompositor(TrueColorCompositor):
             LOG.debug("False color array has shape %r", comp_data.shape)
             LOG.info("Saving false color image to filename '%s'", fn)
             comp_data.tofile(fn)
-            base_product = gridded_scene[all_products[0]]
             gridded_scene[self.composite_name] = self._create_gridded_product(self.composite_name, fn,
                                                                               base_product=base_product,
                                                                               data_kind=self.composite_data_kind)

--- a/polar2grid/core/containers.py
+++ b/polar2grid/core/containers.py
@@ -910,7 +910,7 @@ class GriddedProduct(BaseProduct):
         info = swath_product.copy(as_dict=True)
         for k in ["swath_rows", "swath_cols", "swath_data", "swath_definition"]:
             info.pop(k, None)
-        self.update(**swath_product)
+        self.update(**info)
 
     def get_data_array(self, item="grid_data", mode="r"):
         """Get FBF item as a numpy array.

--- a/polar2grid/glue_legacy.py
+++ b/polar2grid/glue_legacy.py
@@ -495,6 +495,7 @@ def main(argv=sys.argv[1:]):
 
         LOG.info("Processing data for grid %s complete", grid_name)
         # Force deletion and eventual garbage collection of the scene objects
+        gridded_scene.cleanup()
         del gridded_scene
     del scene
     return status_to_return

--- a/polar2grid/glue_legacy.py
+++ b/polar2grid/glue_legacy.py
@@ -495,7 +495,6 @@ def main(argv=sys.argv[1:]):
 
         LOG.info("Processing data for grid %s complete", grid_name)
         # Force deletion and eventual garbage collection of the scene objects
-        gridded_scene.cleanup()
         del gridded_scene
     del scene
     return status_to_return


### PR DESCRIPTION
This was an issue that @kathys identified but had trouble nailing down the exact cause and reproducing it. She sent me a log for one such case and I have an idea for what's going on. Bottom line this should fix this issue.

## Details

Doing `del gridded_scene` in python (see code changes for this PR) is meant to delete the current gridded scene and let python's garbage collector remove things when it wants. As part of deleting the gridded scene, the flat binary files underneath should also be deleted (ex. `true_color.dat`). However, it seems that in some cases this is taking too long and causing issues. Mainly this happens when resampling to multiple grids. If we process grid 1, delete the gridded_scene, move on to process grid 2, we end up creating/using the same flat binary file as the first grid's processing. This can result in P2G deleting the binary file we are currently using, causing issues later in the processing.

## Alternate Solution

I could have also made the filename more unique but I think this should work and is a simpler solution.