### PR TITLE
Add option to enable geotiff multi-threaded compression and overview creation

### DIFF
--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -222,7 +222,7 @@ basic processing with limited products:
                         help="specify the log filename")
     parser.add_argument('--progress', action='store_true',
                         help="show processing progress bar (not recommended for logged output)")
-    parser.add_argument('--num-workers', type=int, default=4,
+    parser.add_argument('--num-workers', type=int, default=os.getenv('DASK_NUM_WORKERS', 4),
                         help="specify number of worker threads to use (default: 4)")
     parser.add_argument('--match-resolution', dest='preserve_resolution', action='store_false',
                         help="When using the 'native' resampler for composites, don't save data "
@@ -237,6 +237,7 @@ basic processing with limited products:
 
     argv_without_help = [x for x in argv if x not in ["-h", "--help"]]
     args, remaining_args = parser.parse_known_args(argv_without_help)
+    os.environ['DASK_NUM_WORKERS'] = str(args.num_workers)
 
     # get the logger if we know the readers and writers that will be used
     if args.reader is not None and args.writers is not None:

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -87,9 +87,10 @@ def add_writer_argument_groups(parser):
                          help="Set tile block Y size")
     group_1.add_argument('--gdal-num-threads', dest='num_threads',
                          default=os.environ.get('DASK_NUM_WORKERS', 4),
-                         help='Set number of threads used for compressing '
-                              'geotiffs (default: Same as num-workers)')
-    group_1.add_argument('--overviews',
+                         help=SUPPRESS)  # don't show this option to the user
+                         # help='Set number of threads used for compressing '
+                         #      'geotiffs (default: Same as num-workers)')
+    group_1.add_argument('--overviews', type=lambda x: x.split(' '),
                          help="Build lower resolution versions of your image "
                               "for better performance in some clients. "
                               "Specified as a space separate list of numbers, "

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -37,6 +37,7 @@ any invalid or missing data pixels. This results in invalid pixels showing up
 as transparent in most image viewers.
 
 """
+import os
 import logging
 from polar2grid.core.dtype import NUMPY_DTYPE_STRS, str_to_dtype, int_or_float
 
@@ -84,6 +85,15 @@ def add_writer_argument_groups(parser):
                          help="Set tile block X size")
     group_1.add_argument('--blockysize', default=SUPPRESS, type=int,
                          help="Set tile block Y size")
+    group_1.add_argument('--gdal-num-threads', dest='num_threads',
+                         default=os.environ.get('DASK_NUM_WORKERS', 4),
+                         help='Set number of threads used for compressing '
+                              'geotiffs (default: Same as num-workers)')
+    group_1.add_argument('--overviews',
+                         help="Build lower resolution versions of your image "
+                              "for better performance in some clients. "
+                              "Specified as a space separate list of numbers, "
+                              "typically as powers of 2. Example: '2 4 8 16'")
     # Saving specific keyword arguments
     # group_2 = parser.add_argument_group(title='Writer Save')
     return group_1, None


### PR DESCRIPTION
I recently discovered that rasterio (gdal), the library we use in satpy/trollimage to save geotiffs, allows for you to specify how many threads are used when compressing the image data. For slow compression algorithms like DEFLATE this can make a big difference in amount of time it takes to save the data to disk.

To enable this I needed to pass a `num_threads` keyword argument to Satpy. The easiest way to do this is to make a command line argument, but since this argument can easily default to the number of dask workers used (`--num-workers`) and in most cases shouldn't need to be defined by the user. So I've decided to hide the option and have it default to the number of dask workers.