### PR TITLE
Fix VIIRS Flood being an LA image when it should be L only

### DIFF
--- a/polar2grid/core/rescale.py
+++ b/polar2grid/core/rescale.py
@@ -431,11 +431,6 @@ def water_temp_palettize(img, min_out, max_out, min_in=0, max_in=1.0, colormap=N
     img[img == 150] = 31
     img[img == 199] = 18
     img[img >= 200] -= 100
-
-    # Convert to an LA image
-    good_data_mask = kwargs['good_data_mask']
-    alpha = numpy.where(good_data_mask, max_out, 0)
-    img = numpy.concatenate((img, alpha), axis=0)
     return img
 
 
@@ -522,7 +517,9 @@ class Rescaler(roles.INIConfigReader):
             is_colormapped = 'palettize' in method or 'colorize' in method
             # trollimage functions need a 2D image
             if is_colormapped:
+                print(data.shape)
                 good_data = rescale_func(data, good_data_mask=good_data_mask, **rescale_options)
+                print(good_data.shape)
                 return good_data
             else:
                 good_data = data[good_data_mask]
@@ -617,6 +614,7 @@ class Rescaler(roles.INIConfigReader):
         inc_by_one = rescale_options.pop("inc_by_one")
 
         data = gridded_product.copy_array(read_only=False)
+        print(data.shape)
         good_data_mask = ~gridded_product.get_data_mask()
         rescale_options['attrs'] = gridded_product  # copy metadata as keyword argument
         if rescale_options.get("separate_rgb", True) and data.ndim == 3:
@@ -628,6 +626,7 @@ class Rescaler(roles.INIConfigReader):
         else:
             data = self._rescale_data(method, data, good_data_mask, rescale_options, fill_value,
                                       clip=clip, mask_clip=mask_clip, inc_by_one=inc_by_one, clip_zero=clip_zero)
+        print(data.shape)
 
         log_level = logging.getLogger('').handlers[0].level or 0
         # Only perform this calculation if it will be shown, its very time consuming


### PR DESCRIPTION
Closes #244 

I had discovered in the past that the VIIRS Active Fire products were producing an LA + color table geotiff but this isn't actually a valid format. When I fixed this for fires I never actually fixed it for the VIIRS EDR Flood product which has a special rescaling/enhancement function. This PR fixes that.