### PR TITLE
Ignore library warnings in Polar2Grid glue script

### DIFF
--- a/polar2grid/core/rescale.py
+++ b/polar2grid/core/rescale.py
@@ -517,9 +517,7 @@ class Rescaler(roles.INIConfigReader):
             is_colormapped = 'palettize' in method or 'colorize' in method
             # trollimage functions need a 2D image
             if is_colormapped:
-                print(data.shape)
                 good_data = rescale_func(data, good_data_mask=good_data_mask, **rescale_options)
-                print(good_data.shape)
                 return good_data
             else:
                 good_data = data[good_data_mask]
@@ -614,7 +612,6 @@ class Rescaler(roles.INIConfigReader):
         inc_by_one = rescale_options.pop("inc_by_one")
 
         data = gridded_product.copy_array(read_only=False)
-        print(data.shape)
         good_data_mask = ~gridded_product.get_data_mask()
         rescale_options['attrs'] = gridded_product  # copy metadata as keyword argument
         if rescale_options.get("separate_rgb", True) and data.ndim == 3:
@@ -626,7 +623,6 @@ class Rescaler(roles.INIConfigReader):
         else:
             data = self._rescale_data(method, data, good_data_mask, rescale_options, fill_value,
                                       clip=clip, mask_clip=mask_clip, inc_by_one=inc_by_one, clip_zero=clip_zero)
-        print(data.shape)
 
         log_level = logging.getLogger('').handlers[0].level or 0
         # Only perform this calculation if it will be shown, its very time consuming

--- a/polar2grid/glue_legacy.py
+++ b/polar2grid/glue_legacy.py
@@ -123,7 +123,9 @@ def main_frontend(argv=sys.argv[1:]):
 
     levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG, TRACE_LEVEL]
     setup_logging(console_level=levels[min(4, args.verbosity)], log_filename=args.log_fn)
-    # sys.excepthook = create_exc_handler(LOG.name)
+    if levels[min(3, args.verbosity)] > logging.DEBUG:
+        import warnings
+        warnings.filterwarnings("ignore")
     LOG.debug("Starting script with arguments: %s", " ".join(sys.argv))
 
     list_products = args.subgroup_args["Frontend Initialization"].pop("list_products")


### PR DESCRIPTION
@kathys noticed that the newest P2G beta tarball is producing a lot more warnings than it used to. This is caused by a new version of pyproj and there is no reason the user needs to see these.