### PR TITLE
Fix gtiff2mp4.sh not using a bash variable properly

### DIFF
--- a/NEWS_GEO2GRID.rst
+++ b/NEWS_GEO2GRID.rst
@@ -4,13 +4,14 @@ Release Notes
 Version 1.0.1 (unreleased)
 --------------------------
 
+* Significantly improved performance by enabling multithreaded geotiff compression
 * Fix resampling freezing when output grid was larger than 1024x1024
 * Fix crash when certain RGBs were created with '--ll-bbox'
 * Add missing '--radius-of-influence' flag for nearest neighbor resampling
 * Add ability to native resample to lower resolution grids
 * Add 'goes_east_Xkm' and 'goes_west_Xkm' grids for easier lower resolution resampling
-* Enable multithreaded geotiff compression
 * Add AHI airmass, ash, dust, fog, and night_microphysics RGBs
+* Accept PNG or GeoTIFFs with gtiff2mp4.sh video generation
 
 Version 1.0.0 (2019-03-01)
 --------------------------

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -65,7 +65,7 @@ What's New?
 
     .. include:: NEWS_GEO2GRID.rst
         :start-line: 6
-        :end-line: 13
+        :end-line: 14
 
     For more details on what's new in this version and past versions see the
     `Release Notes <https://raw.githubusercontent.com/ssec/polar2grid/master/NEWS_GEO2GRID.rst>`_
@@ -106,13 +106,13 @@ System Requirements
     Execution Times
     ---------------
 
-    The following table provides execution time averages for creating all default 
-    GeoTIFF images at full spatial resolution for the given instrument and sector.  
-    Eight computer threads were used. The times are provided for the higher end 
-    system defined above. Execution times decrease when fewer bands and smaller 
+    The following table provides execution time averages for creating all default
+    GeoTIFF images at full spatial resolution for the given instrument and sector.
+    Eight computer threads were used. The times are provided for the higher end
+    system defined above. Execution times decrease when fewer bands and smaller
     regions are processed.
 
-    **Table of Execution Times for Creating GeoTIFF default Images** 
+    **Table of Execution Times for Creating GeoTIFF default Images**
     (All bands plus true and natural color images)
 
     +------------------+---------------------+-----------------+-----------------------------+

--- a/swbundle/gtiff2mp4.sh
+++ b/swbundle/gtiff2mp4.sh
@@ -116,7 +116,7 @@ done
 echo "Generating animation..."
 INPUT_PARAMS=${INPUT_PARAMS:--framerate 24 -f image2}
 OUTPUT_PARAMS=${OUTPUT_PARAMS:--c:v libx264 -crf 25 -vf "format=yuv420p,scale=trunc(iw/2)*2:trunc(ih/2)*2"}
-ffmpeg -y $INPUT_PARAMS -i "${TMP_FRAME_DIR}/%03d.{FILE_EXT}" $OUTPUT_PARAMS $OUTPUT_FILENAME
+ffmpeg -y $INPUT_PARAMS -i "${TMP_FRAME_DIR}/%03d.${FILE_EXT}" $OUTPUT_PARAMS $OUTPUT_FILENAME
 
 
 echo "Done"


### PR DESCRIPTION
@kathys found in her testing that the "small" changes I made to `gtiff2mp4.sh` to accept geotiffs or PNGs as input wasn't working. I had a typo where I forgot the `$` in front of a bash variable usage. This fixes it and adds information about this PNG handling to the release notes.