### PR TITLE
Add note about day/night transition change in G2G release notes

### DIFF
--- a/NEWS_GEO2GRID.rst
+++ b/NEWS_GEO2GRID.rst
@@ -5,6 +5,7 @@ Version 1.0.1 (unreleased)
 --------------------------
 
 * Significantly improved performance by enabling multithreaded geotiff compression
+* Improve day/night transition region in day/night composites
 * Fix resampling freezing when output grid was larger than 1024x1024
 * Fix crash when certain RGBs were created with '--ll-bbox'
 * Add missing '--radius-of-influence' flag for nearest neighbor resampling

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -65,7 +65,7 @@ What's New?
 
     .. include:: NEWS_GEO2GRID.rst
         :start-line: 6
-        :end-line: 14
+        :end-line: 15
 
     For more details on what's new in this version and past versions see the
     `Release Notes <https://raw.githubusercontent.com/ssec/polar2grid/master/NEWS_GEO2GRID.rst>`_


### PR DESCRIPTION
Satpy had a change to how "tight" the day/night transition is by default. This PR makes sure to mention this in the release notes.