### PR TITLE
Clear LD_LIBRARY_PATH in conda-based distributions

### DIFF
--- a/swbundle/env.sh
+++ b/swbundle/env.sh
@@ -42,6 +42,9 @@ if [ -z "$POLAR2GRID_REV" ]; then
 
     # Don't let someone else's PYTHONPATH mess us up
     unset PYTHONPATH
+    export PYTHONNOUSERSITE=1
+    unset LD_PRELOAD
+    unset DYLD_LIBRARY_PATH
     unset LD_LIBRARY_PATH
 
     export P2G_SHELLB3_DIR=$POLAR2GRID_HOME/common/ShellB3

--- a/swbundle/env.sh
+++ b/swbundle/env.sh
@@ -42,6 +42,7 @@ if [ -z "$POLAR2GRID_REV" ]; then
 
     # Don't let someone else's PYTHONPATH mess us up
     unset PYTHONPATH
+    unset LD_LIBRARY_PATH
 
     export P2G_SHELLB3_DIR=$POLAR2GRID_HOME/common/ShellB3
     if [ ! -d $P2G_SHELLB3_DIR ]; then


### PR DESCRIPTION
A recent mailing list post had issues with finding the NetCDF library. This made me think that they had `LD_LIBRARY_PATH` set which shouldn't have been a problem because the `env.sh` script is supposed to remove that. However, after looking I noticed that it only does this for the legacy ShellB3 builds of Polar2Grid. This PR fixes this by doing it for conda-based distributions too.