### PR TITLE
Fix race condition causing crefl to delete files during processing

### DIFF
--- a/polar2grid/crefl/crefl2swath.py
+++ b/polar2grid/crefl/crefl2swath.py
@@ -609,7 +609,9 @@ class Frontend(roles.FrontendRole):
             # Short term hack: delete/cleanup swath products and swath definitions
             for cname, child in scene.items():
                 child['swath_definition'].cleanup()
+                child['swath_definition'].set_persist()
                 child.cleanup()
+                child.set_persist()
         except (ValueError, RuntimeError, OSError):
             LOG.error("Could not create modis crefl files from SDRs")
             raise
@@ -652,7 +654,9 @@ class Frontend(roles.FrontendRole):
             # Short term hack: delete/cleanup swath products and swath definitions
             for cname, child in scene.items():
                 child['swath_definition'].cleanup()
+                child['swath_definition'].set_persist()
                 child.cleanup()
+                child.set_persist()
         except (ValueError, RuntimeError, OSError):
             LOG.error("Could not create crefl files from SDRs")
             raise


### PR DESCRIPTION
@kathys noticed that her operational processing was failing to create CREFL-based true and false color RGB composites. This was caused by the M-band longitude and latitude magically being deleted in the middle of processing. This PR fixes this.

Honestly, this is a workaround fix and not the "right way" to do this. However, this code won't be used much longer so no need to fix it the right way.