### PR TITLE
Update release notes for 1.0.2 release

### DIFF
--- a/NEWS_GEO2GRID.rst
+++ b/NEWS_GEO2GRID.rst
@@ -1,7 +1,12 @@
 Release Notes
 =============
 
-Version 1.0.1 (unreleased)
+Version 1.0.2 (unreleased)
+--------------------------
+
+* Add workaround for threading issue in pyresample
+
+Version 1.0.1 (2020-03-18)
 --------------------------
 
 * Significantly improved performance by enabling multithreaded geotiff compression

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -65,7 +65,7 @@ What's New?
 
     .. include:: NEWS_GEO2GRID.rst
         :start-line: 6
-        :end-line: 15
+        :end-line: 7
 
     For more details on what's new in this version and past versions see the
     `Release Notes <https://raw.githubusercontent.com/ssec/polar2grid/master/NEWS_GEO2GRID.rst>`_


### PR DESCRIPTION
We've been passing out a 1.0.2b0 out to people who needed it. Now with the plan to actually release it, the notes need to be updated to reflect the single change included in the release.