### PR TITLE
Fix VIIRS composite configuration to work with newer Satpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ env:
   global:
     # Set defaults to avoid repeating in most cases
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-    - NUMPY_VERSION=1.18.5
+    - NUMPY_VERSION=stable
     - MAIN_CMD='python setup.py'
-    - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf libtiff sphinx-argparse graphviz python-graphviz pycoast pytest zarr pylibtiff'
+    - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf libtiff sphinx-argparse graphviz python-graphviz pycoast pytest zarr pylibtiff python-geotiepoints'
     - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital'
     - SETUP_XVFB=False
     - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
     # Set defaults to avoid repeating in most cases
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-    - NUMPY_VERSION=stable
+    - NUMPY_VERSION=1.18.5
     - MAIN_CMD='python setup.py'
     - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf libtiff sphinx-argparse graphviz python-graphviz pycoast pytest zarr pylibtiff'
     - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - git clone --depth 1 git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
   - pip install --no-deps git+https://github.com/pytroll/satpy.git
-  - pip install -e .
+  - pip install -e . --no-deps
 script:
   - python -m polar2grid.tests && cd doc && make html
 #  make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
     - NUMPY_VERSION=stable
     - MAIN_CMD='python setup.py'
-    - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf libtiff sphinx-argparse graphviz python-graphviz pycoast pytest zarr'
-    - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
+    - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf libtiff sphinx-argparse graphviz python-graphviz pycoast pytest zarr pylibtiff'
+    - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital'
     - SETUP_XVFB=False
     - EVENT_TYPE='push pull_request'
     - SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - EVENT_TYPE='push pull_request'
     - SETUP_CMD='test'
     - CONDA_CHANNELS='conda-forge'
-    - CONDA_CHANNEL_PRIORITY='True'
+    - CONDA_CHANNEL_PRIORITY='strict'
 matrix:
   include:
   - env: PYTHON_VERSION=3.7

--- a/etc/composites/viirs.yaml
+++ b/etc/composites/viirs.yaml
@@ -4,16 +4,42 @@ modifiers:
   rayleigh_corrected:
     compositor: !!python/name:satpy.composites.viirs.ReflectanceCorrector
     dem_filename: CMGDEM.hdf
-    prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
+    prerequisites: []
+    optional_prerequisites:
+    - name: satellite_azimuth_angle
+      resolution: 742
+    - name: satellite_zenith_angle
+      resolution: 742
+    - name: solar_azimuth_angle
+      resolution: 742
+    - name: solar_zenith_angle
+      resolution: 742
+
+  rayleigh_corrected_iband:
+    compositor: !!python/name:satpy.composites.viirs.ReflectanceCorrector
+    dem_filename: CMGDEM.hdf
+    prerequisites: []
+    optional_prerequisites:
+    - name: satellite_azimuth_angle
+      resolution: 371
+    - name: satellite_zenith_angle
+      resolution: 371
+    - name: solar_azimuth_angle
+      resolution: 371
+    - name: solar_zenith_angle
+      resolution: 371
 
   sunz_corrected:
     compositor: !!python/name:satpy.composites.SunZenithCorrector
     prerequisites:
-    - solar_zenith_angle
+      - name: solar_zenith_angle
+        resolution: 742
+
+  sunz_corrected_iband:
+    compositor: !!python/name:satpy.composites.SunZenithCorrector
+    prerequisites:
+      - name: solar_zenith_angle
+        resolution: 371
 
 composites:
 
@@ -42,7 +68,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
     - name: i01
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
     standard_name: true_color
     high_resolution_band: red
 
@@ -58,7 +84,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
     - name: i01
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
     standard_name: false_color
     high_resolution_band: blue
 
@@ -73,7 +99,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
     - name: i01
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
     standard_name: natural_color
     high_resolution_band: blue
 


### PR DESCRIPTION
Newer versions of Satpy have restructured some of the default VIIRS composite/modifier configurations. This has a weird side effect for the custom configurations in Polar2Grid. For example, in Satpy the rayleigh correction is defined as "rayleigh_corrected" with hard "prerequisites" for the 4 angles needed. In Polar2Grid's older configuration it is also called "rayleigh_corrected" but had all "optional_prerequisites". With the way Satpy handles merging config files this resulted in rayleigh_corrected being defined with both the prereqs and the optional prereqs which was causing weird error messages. This PR should fix them by "coordinating" with the newer Satpy versions.