### PR TITLE
Add day/night filtering using SZA

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,18 @@
+# Releasing the Polar2Grid Python Package
+
+1. Update setup.py with the new version.
+2. Create a git tag for the new version:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Version X.Y.Z"
+   ```
+   
+3. Push the tag to github:
+
+   ```bash
+   git push --follow-tags
+   ```
+   
+4. Create a GitHub release for this tag with name "Version X.Y.Z" and add
+   release notes to the description.
+5. The GitHub release will trigger various GitHub jobs to run. Make sure they succeed.

--- a/etc/composites/viirs.yaml
+++ b/etc/composites/viirs.yaml
@@ -60,17 +60,32 @@ composites:
   true_color:
     compositor: !!python/name:satpy.composites.RatioSharpenedRGB
     prerequisites:
-      # M05
-      - name: _crefl01
-      # M04
-      - name: _crefl04
-      # M03
-      - name: _crefl03
+      - name: M05
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: M04
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: M03
+        modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
-      # I01
-      - name: _crefl08
+      - name: I01
+        modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
     standard_name: true_color
     high_resolution_band: red
+
+#  true_color:
+#    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
+#    prerequisites:
+#      # M05
+#      - name: _crefl01
+#      # M04
+#      - name: _crefl04
+#      # M03
+#      - name: _crefl03
+#    optional_prerequisites:
+#      # I01
+#      - name: _crefl08
+#    standard_name: true_color
+#    high_resolution_band: red
 
   _preenhanced_true_color:
     compositor: !!python/name:polar2grid.composites.enhanced.SingleEnhancedBandCompositor
@@ -192,32 +207,60 @@ composites:
   false_color:
     compositor: !!python/name:satpy.composites.RatioSharpenedRGB
     prerequisites:
-      # M11
-      - name: _crefl07
-      # M07
-      - name: _crefl02
-      # M05
-      - name: _crefl01
+      - name: M11
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: M07
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: M05
+        modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
-      # I02
-      - name: _crefl09
+      - name: I02
+        modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
     standard_name: false_color
     high_resolution_band: green
+#  false_color:
+#    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
+#    prerequisites:
+#      # M11
+#      - name: _crefl07
+#      # M07
+#      - name: _crefl02
+#      # M05
+#      - name: _crefl01
+#    optional_prerequisites:
+#      # I02
+#      - name: _crefl09
+#    standard_name: false_color
+#    high_resolution_band: green
 
   natural_color:
     compositor: !!python/name:satpy.composites.RatioSharpenedRGB
     prerequisites:
-      # M10
-      - name: _crefl06
-      # M07
-      - name: _crefl02
-      # M05
-      - name: _crefl01
+      - name: M10
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: M07
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: M05
+        modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
-      # I02
-      - name: _crefl09
+      - name: I01
+        modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
     standard_name: natural_color
     high_resolution_band: green
+#  natural_color:
+#    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
+#    prerequisites:
+#      # M10
+#      - name: _crefl06
+#      # M07
+#      - name: _crefl02
+#      # M05
+#      - name: _crefl01
+#    optional_prerequisites:
+#      # I02
+#      - name: _crefl09
+#    standard_name: natural_color
+#    high_resolution_band: green
 
   true_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
@@ -247,7 +290,7 @@ composites:
     standard_name: night_microphysics
 
   ifog:
-    compositor: !!python/name:satpy.composites.viirs.VIIRSFog
+    compositor: !!python/name:satpy.composites.DifferenceCompositor
     prerequisites:
     - I05
     - I04

--- a/etc/enhancements/generic.yaml
+++ b/etc/enhancements/generic.yaml
@@ -33,3 +33,11 @@ enhancements:
       - name: stretch
         method: !!python/name:satpy.enhancements.stretch
         kwargs: {stretch: crude, min_stretch: [0, 0, 0], max_stretch: [1, 1, 1]}
+  temperature_differenece:  # ifog, fog
+    standard_name: temperature_difference
+    operations:
+      - name: temp_diff_stretch
+        method: !!python/name:polar2grid.enhancements.shared.temperature_difference
+        kwargs:
+          min_stretch: -10.0
+          max_stretch: 10.0

--- a/polar2grid/enhancements/shared.py
+++ b/polar2grid/enhancements/shared.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Enhancement functions shared between multiple sensors."""
+
+import numpy as np
+
+
+def temperature_difference(img, min_stretch, max_stretch, **kwargs):
+    """Scale data linearly with a buffer on the edges for over limit data.
+
+    Basic behavior is to put -10 to 10 range into 5 to 205 with clipped data
+    set to 4 and 206.
+
+    """
+
+    img.crude_stretch(min_stretch, max_stretch)
+    # we assume uint8 images for legacy AWIPS comparisons
+    offset = 1 / 255.0
+    img.data = img.data * 0.8
+    img.data = np.clip(img.data, -offset, 0.8 + offset)  # 4 and 206 offset
+    img.data + img.data + 5 * offset  # lower bound of 5
+    return img
+
+

--- a/polar2grid/filters/__init__.py
+++ b/polar2grid/filters/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+
+from ._filter_scene import filter_scene

--- a/polar2grid/filters/_filter_scene.py
+++ b/polar2grid/filters/_filter_scene.py
@@ -27,7 +27,7 @@ from typing import Union, Optional, List, Dict
 import logging
 
 from satpy import Scene
-from .day_night import DayCoverageFilter
+from .day_night import DayCoverageFilter, NightCoverageFilter
 
 logger = logging.getLogger(__name__)
 
@@ -72,14 +72,13 @@ def _filter_scene_night_only_products(input_scene: Scene, filter_criteria: dict,
                                       sza_threshold: float = 100.0,
                                       night_fraction: Optional[float] = None):
     """Run filtering for products that need a certain amount of day data."""
-    raise NotImplementedError()
     if night_fraction is None:
         night_fraction = 0.1
-    logger.info("Running day coverage filtering...")
-    day_filter = DayCoverageFilter(filter_criteria,
-                                   sza_threshold=sza_threshold,
-                                   night_fraction=night_fraction)
-    return day_filter.filter_scene(input_scene)
+    logger.info("Running night coverage filtering...")
+    night_filter = NightCoverageFilter(filter_criteria,
+                                       sza_threshold=sza_threshold,
+                                       night_fraction=night_fraction)
+    return night_filter.filter_scene(input_scene)
 
 
 def filter_scene(input_scene: Scene,

--- a/polar2grid/filters/_filter_scene.py
+++ b/polar2grid/filters/_filter_scene.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Helper functions for filtering certain products."""
+
+import importlib
+from typing import Union, Optional, List, Dict
+import logging
+
+from satpy import Scene
+from .day_night import DayCoverageFilter
+
+logger = logging.getLogger(__name__)
+
+
+def _merge_filter_critera(*readers_criteria: Dict[str, Union[List[str], None]]):
+    result = {}
+    for reader_criteria in readers_criteria:
+        for criteria_key, criteria_value in reader_criteria.items():
+            if criteria_value is not None:
+                result.setdefault(criteria_key, []).extend(criteria_value)
+    return result
+
+
+def _get_single_reader_filter_criteria(reader: str, filter_name: str):
+    reader_mod = importlib.import_module('polar2grid.readers.' + reader)
+    filter_criteria = getattr(reader_mod, 'FILTERS', {})
+    return filter_criteria[filter_name]
+
+
+def get_reader_filter_criteria(reader_names: List[str], filter_name: str):
+    """Get reader configured filter information."""
+    readers_criteria = [_get_single_reader_filter_criteria(reader, filter_name)
+                        for reader in reader_names]
+    criteria = _merge_filter_critera(*readers_criteria)
+    return criteria
+
+
+def _filter_scene_day_only_products(input_scene: Scene, filter_criteria: dict,
+                                    sza_threshold: float = 100.0,
+                                    day_fraction: Optional[float] = None):
+    """Run filtering for products that need a certain amount of day data."""
+    if day_fraction is None:
+        day_fraction = 0.1
+    logger.info("Running day coverage filtering...")
+    day_filter = DayCoverageFilter(filter_criteria,
+                                   sza_threshold=sza_threshold,
+                                   day_fraction=day_fraction)
+    return day_filter.filter_scene(input_scene)
+
+
+def _filter_scene_night_only_products(input_scene: Scene, filter_criteria: dict,
+                                      sza_threshold: float = 100.0,
+                                      night_fraction: Optional[float] = None):
+    """Run filtering for products that need a certain amount of day data."""
+    raise NotImplementedError()
+    if night_fraction is None:
+        night_fraction = 0.1
+    logger.info("Running day coverage filtering...")
+    day_filter = DayCoverageFilter(filter_criteria,
+                                   sza_threshold=sza_threshold,
+                                   night_fraction=night_fraction)
+    return day_filter.filter_scene(input_scene)
+
+
+def filter_scene(input_scene: Scene,
+                 reader_names: List[str],
+                 sza_threshold: float = 100.0,
+                 day_fraction: Optional[float] = None,
+                 night_fraction: Optional[float] = None,
+                 ):
+    if day_fraction is not False:
+        criteria = get_reader_filter_criteria(reader_names, 'day_only')
+        input_scene = _filter_scene_day_only_products(
+            input_scene,
+            criteria,
+            sza_threshold=sza_threshold,
+            day_fraction=day_fraction,
+        )
+    if night_fraction is not False:
+        criteria = get_reader_filter_criteria(reader_names, 'night_only')
+        input_scene = _filter_scene_night_only_products(
+            input_scene,
+            criteria,
+            sza_threshold=sza_threshold,
+            night_fraction=night_fraction,
+        )
+    return input_scene

--- a/polar2grid/filters/day_night.py
+++ b/polar2grid/filters/day_night.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Filter classes for making decisions based on day or night percentages."""
+
+import logging
+
+try:
+    # Python 3.9+
+    from functools import cache
+except ImportError:
+    from functools import lru_cache as cache
+
+import numpy as np
+from xarray import DataArray
+from satpy import Scene
+import dask.array as da
+from pyorbital.astronomy import sun_zenith_angle
+from pyresample.boundary import AreaDefBoundary, Boundary
+from pyresample.spherical import SphPolygon
+from pyresample.geometry import get_geostationary_bounding_box, SwathDefinition
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def _get_sunlight_coverage(area_def, start_time, sza_threshold=90, overpass=None):
+    """Get the sunlight coverage of *area_def* at *start_time* as a value between 0 and 1."""
+    if isinstance(area_def, SwathDefinition):
+        lons, lats = area_def.get_lonlats()
+        freq = int(lons.shape[-1] * 0.10)
+        lons, lats = da.compute(lons[::freq, ::freq], lats[::freq, ::freq])
+        adp = Boundary(lons.ravel(), lats.ravel()).contour_poly
+    elif area_def.is_geostationary:
+        adp = Boundary(
+            *get_geostationary_bounding_box(area_def,
+                                            nb_points=100)).contour_poly
+    else:
+        adp = AreaDefBoundary(area_def, frequency=100).contour_poly
+    poly = get_twilight_poly(start_time)
+    if overpass is not None:
+        ovp = overpass.boundary.contour_poly
+        cut_area_poly = adp.intersection(ovp)
+    else:
+        cut_area_poly = adp
+
+    if cut_area_poly is None:
+        if not adp._is_inside(ovp):
+            return 0.0
+        else:
+            # Should already have been taken care of in pyresample.spherical.intersection
+            cut_area_poly = adp
+
+    daylight = cut_area_poly.intersection(poly)
+    if daylight is None:
+        if sun_zenith_angle(start_time, *area_def.get_lonlat(0, 0)) < sza_threshold:
+            return 1.0
+        else:
+            return 0.0
+    else:
+        daylight_area = daylight.area()
+        total_area = adp.area()
+        return daylight_area / total_area
+
+
+def modpi(val, mod=np.pi):
+    """Puts *val* between -*mod* and *mod*."""
+    return (val + mod) % (2 * mod) - mod
+
+
+def get_twilight_poly(utctime):
+    """Return a polygon enclosing the sunlit part of the globe at *utctime*."""
+    from pyorbital import astronomy
+    ra, dec = astronomy.sun_ra_dec(utctime)
+    lon = modpi(ra - astronomy.gmst(utctime))
+    lat = dec
+
+    vertices = np.zeros((4, 2))
+
+    vertices[0, :] = modpi(lon - np.pi / 2), 0
+    if lat <= 0:
+        vertices[1, :] = lon, np.pi / 2 + lat
+        vertices[3, :] = modpi(lon + np.pi), -(np.pi / 2 + lat)
+    else:
+        vertices[1, :] = modpi(lon + np.pi), np.pi / 2 - lat
+        vertices[3, :] = lon, -(np.pi / 2 - lat)
+
+    vertices[2, :] = modpi(lon + np.pi / 2), 0
+
+    return SphPolygon(vertices)
+
+
+class DayCoverageFilter(object):
+    """Remove certain products when there is not enough day data."""
+
+    def __init__(self,
+                 product_filter_criteria: dict = None,
+                 sza_threshold: float = 100.0,
+                 day_fraction: float = 0.1):
+        """Initialize thresholds and default search criteria."""
+        self._filter_criteria = product_filter_criteria or {}
+        matching_standard_names = ['toa_bidirectional_reflectance', 'true_color', 'natural_color', 'false_color']
+        self._filter_criteria.setdefault('standard_name', matching_standard_names)
+        self._sza_threshold = sza_threshold
+        self._day_fraction = day_fraction
+
+    def _matches_criteria(self, data_arr: DataArray):
+        sname_match = self._filter_criteria.get('standard_name')
+        attrs = data_arr.attrs
+        if attrs.get('standard_name') in sname_match:
+            return True
+        return False
+
+    def _filter_data_array(self, data_arr: DataArray, _cache: dict):
+        """Check if this DataArray should be removed.
+
+        Returns:
+            True if it meets the condition and does not have enough
+            day data and should therefore be removed. False otherwise
+            meaning it should be kept.
+
+        """
+        if not self._matches_criteria(data_arr):
+            return False
+
+        area = data_arr.attrs['area']
+        start_time = data_arr.attrs['start_time']
+        end_time = data_arr.attrs['end_time']
+        mid_time = start_time + (end_time - start_time) / 2
+        sza_threshold = self._sza_threshold
+        day_fraction = self._day_fraction
+        if area not in _cache:
+            slc = _get_sunlight_coverage(area, mid_time, sza_threshold)
+            logger.debug("Sunlight is estimated to cover %0.2f%% of the scene.", slc * 100)
+            should_be_filtered = slc < day_fraction
+            _cache[area] = should_be_filtered
+        return _cache[area]
+
+    def filter_scene(self, scene: Scene):
+        """Create a new Scene with filtered DataArrays removed."""
+        _cache = {}
+        remaining_ids = []
+        for data_id in scene.keys():
+            logger.debug("Analyzing '{}' for filtering...".format(data_id))
+            if not self._filter_data_array(scene[data_id], _cache):
+                remaining_ids.append(data_id)
+            else:
+                logger.info("Unloading '{}' because there is not enough day data.".format(data_id))
+        if not remaining_ids:
+            return None
+        new_scn = scene.copy(remaining_ids)
+        new_scn._wishlist = scene._wishlist.copy()
+        return new_scn

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -187,7 +187,7 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
                               "is night time (no valid reflectances). The "
                               "list of products checked is currently limited "
                               "to reflectance bands and true and false color "
-                              "composites. Default is 0.1 (at least 10% "
+                              "composites. Default is 0.1 (at least 10%% "
                               "night).")
     group_1.add_argument('--sza-threshold', type=float,
                          default=100,

--- a/polar2grid/readers/viirs_sdr.py
+++ b/polar2grid/readers/viirs_sdr.py
@@ -229,10 +229,11 @@ PRODUCT_ALIASES['awips_true_color'] = ['viirs_crefl08', 'viirs_crefl04', 'viirs_
 PRODUCT_ALIASES['awips_false_color'] = ['viirs_crefl07', 'viirs_crefl09', 'viirs_crefl08']
 
 FILTERS = {
-    'day': {
-        'standard_name': ['toa_bidirectional_reflectance', 'true_color', 'false_color', 'natural_color'],
+    'day_only': {
+        'standard_name': ['toa_bidirectional_reflectance', 'true_color', 'false_color', 'natural_color',
+                          'corrected_reflectance'],
     },
-    'night': {
+    'night_only': {
         'standard_name': ['temperature_difference'],
     }
 }

--- a/polar2grid/readers/viirs_sdr.py
+++ b/polar2grid/readers/viirs_sdr.py
@@ -20,13 +20,6 @@
 # satellite observation data, remaps it, and writes it to a file format for
 # input into another program.
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
-#
-#     Written by David Hoese    March 2016
-#     University of Wisconsin-Madison
-#     Space Science and Engineering Center
-#     1225 West Dayton Street
-#     Madison, WI  53706
-#     david.hoese@ssec.wisc.edu
 """The VIIRS SDR Reader operates on Science Data Record (SDR) HDF5 files from
 the Suomi National Polar-orbiting Partnership's (NPP) and/or the NOAA20
 Visible/Infrared Imager Radiometer Suite (VIIRS) instrument. The VIIRS
@@ -217,7 +210,10 @@ TRUE_COLOR_PRODUCTS = [
 FALSE_COLOR_PRODUCTS = [
     "false_color"
 ]
-DEFAULT_PRODUCTS = I_PRODUCTS + M_PRODUCTS + DNB_PRODUCTS[1:] + TRUE_COLOR_PRODUCTS + FALSE_COLOR_PRODUCTS
+OTHER_COMPS = [
+    "ifog",
+]
+DEFAULT_PRODUCTS = I_PRODUCTS + M_PRODUCTS + DNB_PRODUCTS[1:] + TRUE_COLOR_PRODUCTS + FALSE_COLOR_PRODUCTS + OTHER_COMPS
 
 # map all lowercase band names to uppercase names
 PRODUCT_ALIASES = {}
@@ -231,6 +227,15 @@ for band in I_PRODUCTS + M_PRODUCTS:
 
 PRODUCT_ALIASES['awips_true_color'] = ['viirs_crefl08', 'viirs_crefl04', 'viirs_crefl03']
 PRODUCT_ALIASES['awips_false_color'] = ['viirs_crefl07', 'viirs_crefl09', 'viirs_crefl08']
+
+FILTERS = {
+    'day': {
+        'standard_name': ['toa_bidirectional_reflectance', 'true_color', 'false_color', 'natural_color'],
+    },
+    'night': {
+        'standard_name': ['temperature_difference'],
+    }
+}
 
 
 def add_reader_argument_groups(parser):

--- a/polar2grid/resample/_resample_scene.py
+++ b/polar2grid/resample/_resample_scene.py
@@ -228,6 +228,7 @@ def resample_scene(input_scene, areas_to_resample, grid_configs, resampler,
                 # which means we have to save this Scene's datasets
                 # because they won't be saved
                 new_scn = input_scene.copy(datasets=data_ids)
-            scenes_to_save.append((new_scn, resampled_products))
+            _resampled_products = resampled_products & set(new_scn.keys())
+            scenes_to_save.append((new_scn, _resampled_products))
 
     return scenes_to_save


### PR DESCRIPTION
Porting some functionality from legacy Polar2Grid to Polar2Grid 3.0 with pyresample features instead of forcing SZA to be loaded.

This adds a `--filter-day-products` and `--filter-night-products` flag to control if filtering based on amount of day/night should be done and how much day/night is needed for a day-only/night-only product to be generated (as a fraction of the overall Scene). This also uses a `--sza-threshold` flag to control where the transition point is between day and night as the angle in degrees (default 100).