### PR TITLE
Hide '--fix-awips' flag as it is deprecated in Satpy

### DIFF
--- a/doc/source/writers/scmi.rst
+++ b/doc/source/writers/scmi.rst
@@ -1,32 +1,17 @@
-AWIPS SCMI Writer
-=================
+AWIPS Tiled Writer
+==================
 
-.. ifconfig:: not is_geo2grid
-
-    .. automodule:: polar2grid.awips.scmi_backend
-
-.. ifconfig:: is_geo2grid
-
-    .. automodule:: polar2grid.writers.scmi
-
+.. automodule:: polar2grid.writers.scmi
 
 Command Line Arguments
 ----------------------
 
-.. ifconfig:: not is_geo2grid
-
-    .. argparse::
-        :module: polar2grid.awips.scmi_backend
-        :func: add_backend_argument_groups
-        :prog: polar2grid.sh <reader> scmi
-        :passparser:
-
 .. ifconfig:: is_geo2grid
 
     .. argparse::
-        :module: polar2grid.writers.scmi
+        :module: polar2grid.writers.awips_tiled
         :func: add_writer_argument_groups
-        :prog: |script| -r <reader> -w scmi
+        :prog: |script| -r <reader> -w awips_tiled
         :passparser:
 
 .. raw:: latex
@@ -70,14 +55,14 @@ Examples:
 
     .. code-block:: bash
 
-        polar2grid.sh acspo scmi --letters --compress -g lcc_conus_300 --sector-id LCC  --grid-coverage=0.0 -f 20170717185500-STAR-L2P_GHRSST-SSTskin-MODIS_T-ACSPO_V2.40-v02.0-fv01.0.nc
+        polar2grid.sh -r acspo -w awips_tiled --letters --compress -g lcc_conus_300 --sector-id LCC -f 20170717185500-STAR-L2P_GHRSST-SSTskin-MODIS_T-ACSPO_V2.40-v02.0-fv01.0.nc
 
-        polar2grid.sh clavrx scmi --sector-id Polar --letters --compress -g polar_alaska_700 -p refl_lunar_dnb_nom cloud_phase cld_height_acha --grid-coverage=0.0 -f /data/clavrx_npp_d20170706_t0806562_e0808204_b29481.level2.hdf
+        polar2grid.sh -r clavrx -w awips_tiled --sector-id Polar --letters --compress -g polar_alaska_700 -p refl_lunar_dnb_nom cloud_phase cld_height_acha -f /data/clavrx_npp_d20170706_t0806562_e0808204_b29481.level2.hdf
 
-        polar2grid.sh viirs_sdr scmi -g merc_pacific_1km --sector-id Pacific --letters --compress -f /path/to/files*.h5
+        polar2grid.sh -r viirs_sdr -w awips_tiled -g merc_pacific_1km --sector-id Pacific --letters --compress -f /path/to/files*.h5
 
 .. ifconfig:: is_geo2grid
 
     .. code-block:: bash
 
-        geo2grid.sh abi_l1b scmi --letters --compress --sector-id GOES_EAST -f /path/to/files*.nc
+        geo2grid.sh -r abi_l1b -w awips_tiled --letters --compress --sector-id GOES_EAST -f /path/to/files*.nc

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -57,7 +57,6 @@ LOG = logging.getLogger(__name__)
 
 WRITER_PARSER_FUNCTIONS = {
     'geotiff': geotiff.add_writer_argument_groups,
-    'scmi': awips_tiled.add_writer_argument_groups,
     'awips_tiled': awips_tiled.add_writer_argument_groups,
 }
 

--- a/polar2grid/writers/awips_tiled.py
+++ b/polar2grid/writers/awips_tiled.py
@@ -86,6 +86,7 @@ LOG = logging.getLogger(__name__)
 
 
 def add_writer_argument_groups(parser, group=None):
+    import argparse
     DEFAULT_OUTPUT_PATTERN = '{source_name}_AII_{platform_name}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
     if group is None:
         group = parser.add_argument_group(title='SCMI Writer')
@@ -94,7 +95,8 @@ def add_writer_argument_groups(parser, group=None):
     group.add_argument("--compress", action="store_true",
                        help="zlib compress each netcdf file")
     group.add_argument("--fix-awips", action="store_true",
-                       help="modify NetCDF output to work with the old/broken AWIPS NetCDF library")
+                       help=argparse.SUPPRESS)
+                       # help="modify NetCDF output to work with the old/broken AWIPS NetCDF library")
     group.add_argument('--output-filename', dest='filename', default=DEFAULT_OUTPUT_PATTERN,
                        help='custom file pattern to save dataset to')
     group.add_argument('--use-end-time', action='store_true',

--- a/polar2grid/writers/awips_tiled.py
+++ b/polar2grid/writers/awips_tiled.py
@@ -89,7 +89,7 @@ def add_writer_argument_groups(parser, group=None):
     import argparse
     DEFAULT_OUTPUT_PATTERN = '{source_name}_AII_{platform_name}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
     if group is None:
-        group = parser.add_argument_group(title='SCMI Writer')
+        group = parser.add_argument_group(title='AWIPS Tiled Writer')
     # group_1.add_argument('--file-pattern', default=DEFAULT_OUTPUT_PATTERN,
     #                      help="Custom file pattern to save dataset to")
     group.add_argument("--compress", action="store_true",


### PR DESCRIPTION
The `fix_awips` keyword argument has been deprecated (or will be) in the Satpy 'awips_tiled' writer. I had to do this because of some odd xarray/dask hanging I was experience and supporting this flag only complicated the matter. As far as I know this flag is no longer needed as all AWIPS workstations have been updated by the NWS and don't run into this bug anymore. The bug was that AWIPS was using an old version of HDF5/NetCDF4 for Java and it was unable to parse NetCDF files created with newer versions of the NetCDF4 library.