### PR TITLE
Fix resampling when areas and resampler are both provided

### DIFF
--- a/polar2grid/core/containers.py
+++ b/polar2grid/core/containers.py
@@ -660,7 +660,7 @@ class GridDefinition(GeographicDefinition):
                 proj4_dict[k] = float(proj4_dict[k])
 
         # load information from PROJ.4 about the ellipsis if possible
-        if "ellps" in proj4_dict and "a" not in proj4_dict or "b" not in proj4_dict:
+        if "ellps" in proj4_dict and ("a" not in proj4_dict or "b" not in proj4_dict):
             import pyproj
             ellps = pyproj.pj_ellps[proj4_dict["ellps"]]
             proj4_dict["a"] = ellps["a"]

--- a/polar2grid/grids/grids.conf
+++ b/polar2grid/grids/grids.conf
@@ -3,38 +3,38 @@
 # Origin Coordinates may use the 'deg' suffix to specify coordinates in lat/lon degrees
 # grid_name,            proj4, proj4_str,                                                                                width,  height, pixel_size_x, pixel_size_y,           origin_x,          origin_y
 # Dynamic Grids
-wgs84_fit,              proj4, +proj=latlong +datum=WGS84 +ellps=WGS84 +no_defs,                                          None,    None,       0.0057,      -0.0057,               None,              None
-latlon,                 proj4, +proj=latlong +datum=WGS84 +ellps=WGS84 +no_defs,                                          None,    None,       0.0057,      -0.0057,               None,              None
-wgs84_fit_250,          proj4, +proj=latlong +datum=WGS84 +ellps=WGS84 +no_defs,                                          None,    None,      0.00225,     -0.00225,               None,              None
-latlon_250,             proj4, +proj=latlong +datum=WGS84 +ellps=WGS84 +no_defs,                                          None,    None,      0.00225,     -0.00225,               None,              None
-wgs84_fit_1km,          proj4, +proj=latlong +datum=WGS84 +ellps=WGS84 +no_defs,                                          None,    None,        0.009,       -0.009,               None,              None
-latlon_1km,             proj4, +proj=latlong +datum=WGS84 +ellps=WGS84 +no_defs,                                          None,    None,        0.009,       -0.009,               None,              None
-lcc_fit,                proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
-lcc_na,                 proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
-lcc_sa,                 proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=-25 +lat_1=-25 +lon_0=-55 +units=m +no_defs,    None,    None,         1000,        -1000,               None,              None
-lcc_eu,                 proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=15 +units=m +no_defs,       None,    None,         1000,        -1000,               None,              None
-lcc_south_africa,       proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=-25 +lat_1=-25 +lon_0=25 +units=m +no_defs,     None,    None,         1000,        -1000,               None,              None
-lcc_aus,                proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=-25 +lat_1=-25 +lon_0=135 +units=m +no_defs,    None,    None,         1000,        -1000,               None,              None
-lcc_asia,               proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=105 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
-lcc_fit_hr,             proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,          400,         -400,               None,              None
-lcc_conus_300,          proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,          300,         -300,               None,              None
-lcc_conus_750,          proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,          750,         -750,               None,              None
-lcc_conus_1km,          proj4, +proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
-eqc_fit,                proj4, +proj=eqc +datum=WGS84 +ellps=WGS84 +lat_ts=0 +lon_0=0 +units=m +no_defs,                  None,    None,          250,         -250,               None,              None
-polar_canada,           proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=45.0 +lon_0=-150 +units=m,         None,    None,         1000,        -1000,               None,              None
-polar_north_pacific,    proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=45.0 +lon_0=-170 +units=m,         None,    None,          400,         -400,               None,              None
-polar_south_pacific,    proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=-90 +lat_ts=-45.0 +lon_0=-170 +units=m,       None,    None,          400,         -400,               None,              None
-polar_russia,           proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=45.0 +lon_0=50 +units=m,           None,    None,          400,         -400,               None,              None
-polar_alaska,           proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          400,         -400,               None,              None
-polar_alaska_300,       proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          300,         -300,               None,              None
-polar_alaska_750,       proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          750,         -750,               None,              None
-polar_alaska_1km,       proj4, +proj=stere +datum=WGS84 +ellps=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,         1000,        -1000,               None,              None
-merc_conus_300,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          300,         -300,               None,              None
-merc_conus_750,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          750,         -750,               None,              None
-merc_conus_1km,         proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,         1000,        -1000,               None,              None
-merc_pacific_300,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          300,         -300,               None,              None
-merc_pacific_750,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          750,         -750,               None,              None
-merc_pacific_1km,       proj4, +proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,         1000,        -1000,               None,              None
+wgs84_fit,              proj4, +proj=latlong +datum=WGS84 +no_defs,                                          None,    None,       0.0057,      -0.0057,               None,              None
+latlon,                 proj4, +proj=latlong +datum=WGS84 +no_defs,                                          None,    None,       0.0057,      -0.0057,               None,              None
+wgs84_fit_250,          proj4, +proj=latlong +datum=WGS84 +no_defs,                                          None,    None,      0.00225,     -0.00225,               None,              None
+latlon_250,             proj4, +proj=latlong +datum=WGS84 +no_defs,                                          None,    None,      0.00225,     -0.00225,               None,              None
+wgs84_fit_1km,          proj4, +proj=latlong +datum=WGS84 +no_defs,                                          None,    None,        0.009,       -0.009,               None,              None
+latlon_1km,             proj4, +proj=latlong +datum=WGS84 +no_defs,                                          None,    None,        0.009,       -0.009,               None,              None
+lcc_fit,                proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
+lcc_na,                 proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
+lcc_sa,                 proj4, +proj=lcc +datum=WGS84 +lat_0=-25 +lat_1=-25 +lon_0=-55 +units=m +no_defs,    None,    None,         1000,        -1000,               None,              None
+lcc_eu,                 proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=15 +units=m +no_defs,       None,    None,         1000,        -1000,               None,              None
+lcc_south_africa,       proj4, +proj=lcc +datum=WGS84 +lat_0=-25 +lat_1=-25 +lon_0=25 +units=m +no_defs,     None,    None,         1000,        -1000,               None,              None
+lcc_aus,                proj4, +proj=lcc +datum=WGS84 +lat_0=-25 +lat_1=-25 +lon_0=135 +units=m +no_defs,    None,    None,         1000,        -1000,               None,              None
+lcc_asia,               proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=105 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
+lcc_fit_hr,             proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,          400,         -400,               None,              None
+lcc_conus_300,          proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,          300,         -300,               None,              None
+lcc_conus_750,          proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,          750,         -750,               None,              None
+lcc_conus_1km,          proj4, +proj=lcc +datum=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs,      None,    None,         1000,        -1000,               None,              None
+eqc_fit,                proj4, +proj=eqc +datum=WGS84 +lat_ts=0 +lon_0=0 +units=m +no_defs,                  None,    None,          250,         -250,               None,              None
+polar_canada,           proj4, +proj=stere +datum=WGS84 +lat_0=90 +lat_ts=45.0 +lon_0=-150 +units=m,         None,    None,         1000,        -1000,               None,              None
+polar_north_pacific,    proj4, +proj=stere +datum=WGS84 +lat_0=90 +lat_ts=45.0 +lon_0=-170 +units=m,         None,    None,          400,         -400,               None,              None
+polar_south_pacific,    proj4, +proj=stere +datum=WGS84 +lat_0=-90 +lat_ts=-45.0 +lon_0=-170 +units=m,       None,    None,          400,         -400,               None,              None
+polar_russia,           proj4, +proj=stere +datum=WGS84 +lat_0=90 +lat_ts=45.0 +lon_0=50 +units=m,           None,    None,          400,         -400,               None,              None
+polar_alaska,           proj4, +proj=stere +datum=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          400,         -400,               None,              None
+polar_alaska_300,       proj4, +proj=stere +datum=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          300,         -300,               None,              None
+polar_alaska_750,       proj4, +proj=stere +datum=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,          750,         -750,               None,              None
+polar_alaska_1km,       proj4, +proj=stere +datum=WGS84 +lat_0=90 +lat_ts=60.0 +lon_0=-150 +units=m,         None,    None,         1000,        -1000,               None,              None
+merc_conus_300,         proj4, +proj=merc +datum=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          300,         -300,               None,              None
+merc_conus_750,         proj4, +proj=merc +datum=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,          750,         -750,               None,              None
+merc_conus_1km,         proj4, +proj=merc +datum=WGS84 +lon_0=-95 +lat_0=0 +units=m +no_defs,                None,    None,         1000,        -1000,               None,              None
+merc_pacific_300,       proj4, +proj=merc +datum=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          300,         -300,               None,              None
+merc_pacific_750,       proj4, +proj=merc +datum=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,          750,         -750,               None,              None
+merc_pacific_1km,       proj4, +proj=merc +datum=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs,                None,    None,         1000,        -1000,               None,              None
 # GOES Grids
 goesr_test_300,         proj4, +proj=geos +a=6378137.0 +b=6356752.31414 +lon_0=-89.5 +units=m +sweep=x +h=35786023.0,     None,    None,          300,         -300,               None,              None
 # Static GOES Grids - Nominal upper-left extent (outer edge) is (-5434894.885056, 5434894.885056)


### PR DESCRIPTION
While helping a user I noticed a few things wrong with the resampling code in certain situations. I also noticed some old bugs in Polar2Grid grid handling code.

By helping the user I realized that we can probably get more accurate projection information in a geotiff if we omit the `ellps` in our `grids.conf` and only provide the `+datum`. Recent versions of PROJ seem to like this better. I've asked some pyproj folks about this to double check.