### PR TITLE
Fix grid coverage checks not using swath boundaries properly

### DIFF
--- a/integration_tests/features/steps/compare_images.py
+++ b/integration_tests/features/steps/compare_images.py
@@ -26,7 +26,7 @@ def step_impl(context, source):
 @when('{command} runs')
 def step_impl(context, command):
     context.script = command.split()[0]
-    context.command = "datapath={}; {} {}".format(context.datapath, os.path.join(context.p2g_path, command),
+    context.command = "datapath={}; /usr/bin/time {} {}".format(context.datapath, os.path.join(context.p2g_path, command),
                                                   context.source)
 
     # creating new data in temporary directory to compare

--- a/polar2grid/filters/_utils.py
+++ b/polar2grid/filters/_utils.py
@@ -45,18 +45,18 @@ def boundary_for_area(area_def: PRGeometry) -> Boundary:
     """Create Boundary object representing the provided area."""
     if isinstance(area_def, SwathDefinition):
         # TODO: Persist lon/lats if requested
-        lons, lats = area_def.get_lonlats()
-        row_freq = int(lons.shape[0] * 0.30)
-        col_freq = int(lons.shape[1] * 0.30)
-        lons, lats = da.compute(lons[::row_freq, ::col_freq],
-                                lats[::row_freq, ::col_freq])
-        adp = Boundary(lons.ravel(), lats.ravel())
+        lons, lats = area_def.get_bbox_lonlats()
+        lons = da.concatenate(lons)
+        lats = da.concatenate(lats)
+        freq = int(lons.shape[0] * 0.05)
+        lons, lats = da.compute(lons[::freq], lats[::freq])
+        adp = Boundary(lons, lats)
     elif area_def.is_geostationary:
         adp = Boundary(
             *get_geostationary_bounding_box(area_def,
                                             nb_points=100))
     else:
-        adp = AreaDefBoundary(area_def, frequency=100)
+        adp = AreaDefBoundary(area_def, frequency=int(area_def.shape[0] * 0.30))
     return adp
 
 

--- a/polar2grid/resample/_resample_scene.py
+++ b/polar2grid/resample/_resample_scene.py
@@ -225,16 +225,17 @@ def resample_scene(input_scene, areas_to_resample, grid_configs, resampler,
             area_def = area_resolver[area_name]
             rs = _get_default_resampler(resampler, area_name, area_def, input_scene)
             if area_def is not None:
-                logger.info("Resampling to '%s' using '%s' resampling...", area_name, rs)
-                logger.debug("Resampling to '%s' using resampler '%s' with %s", area_name, rs, _resample_kwargs)
                 scene_to_resample = input_scene
                 if resampler != 'native' and grid_coverage > 0:
+                    logger.info("Checking products for sufficient output grid coverage (grid: '%s')...", area_name)
                     filter = ResampleCoverageFilter(target_area=area_def,
                                                     coverage_fraction=grid_coverage)
                     scene_to_resample = filter.filter_scene(input_scene)
                     if scene_to_resample is None:
                         logger.warning("No products were found to overlap with '%s' grid.", area_name)
                         continue
+                logger.info("Resampling to '%s' using '%s' resampling...", area_name, rs)
+                logger.debug("Resampling to '%s' using resampler '%s' with %s", area_name, rs, _resample_kwargs)
                 new_scn = scene_to_resample.resample(area_def, resampler=rs, **_resample_kwargs)
             elif not preserve_resolution:
                 # the user didn't want to resample to any areas


### PR DESCRIPTION
The `Boundary` objects I'm using only need the outer lon/lat values of the swath. I was providing them with internal ones and it was causing some issues in the results and performance issues. This makes sure to only use the clockwise boundary coordinates.