### PR TITLE
Add Satpy auxiliary data download to bundle creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ ms2gt/src/xy2ll/xy2ll
 
 # PyCharm configs
 .idea
+
+# Example images should not be added to the repository
+doc/source/_static/example_images

--- a/build_environment.yml
+++ b/build_environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - pykdtree
   - pyorbital
   - pyproj
-  - pyresample>=1.18.0
+  - pyresample>=1.18.1
   - pyshp
   - pyspectral
   - python=3.8

--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -132,6 +132,15 @@ $SB_NAME/bin/download_pyspectral_data.sh || oops "Couldn't download pyspectral d
 # Add the download_from_internet: False to the config
 echo "download_from_internet: False" >> ${SB_NAME}/etc/pyspectral.yaml
 
+# Download Satpy auxiliary data
+echo "Downloading Satpy auxiliary data..."
+AUX_CACHE_DIR="${CACHE_DIR}/satpy_aux_data"
+SATPY_DATA_DIR="${SB_NAME}/share/polar2grid/data"
+${SB_NAME}/bin/satpy_retrieve_all_aux_data --data-dir ${AUX_CACHE_DIR}
+echo "Copying Satpy auxiliary data to software bundle..."
+# don't include large geotiff files that we don't use in P2G/G2G
+rsync -auv --exclude "*.tif" ${AUX_CACHE_DIR}/* "${SATPY_DATA_DIR}/"
+
 # Perform extra "risky" operations to make the tarball as small as possible
 # Taken from https://jcrist.github.io/conda-docker-tips.html
 MINIFY_TARBALL=${MINIFY_TARBALL:-1}

--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -136,7 +136,7 @@ echo "download_from_internet: False" >> ${SB_NAME}/etc/pyspectral.yaml
 echo "Downloading Satpy auxiliary data..."
 AUX_CACHE_DIR="${CACHE_DIR}/satpy_aux_data"
 SATPY_DATA_DIR="${SB_NAME}/share/polar2grid/data"
-${SB_NAME}/bin/satpy_retrieve_all_aux_data --data-dir ${AUX_CACHE_DIR}
+${PYTHON_RUNTIME_BASE}/bin/satpy_retrieve_all_aux_data --data-dir ${AUX_CACHE_DIR}
 echo "Copying Satpy auxiliary data to software bundle..."
 # don't include large geotiff files that we don't use in P2G/G2G
 rsync -auv --exclude "*.tif" ${AUX_CACHE_DIR}/* "${SATPY_DATA_DIR}/"

--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -136,10 +136,12 @@ echo "download_from_internet: False" >> ${SB_NAME}/etc/pyspectral.yaml
 echo "Downloading Satpy auxiliary data..."
 AUX_CACHE_DIR="${CACHE_DIR}/satpy_aux_data"
 SATPY_DATA_DIR="${SB_NAME}/share/polar2grid/data"
-${PYTHON_RUNTIME_BASE}/bin/satpy_retrieve_all_aux_data --data-dir ${AUX_CACHE_DIR}
+${PYTHON_RUNTIME_BASE}/bin/satpy_retrieve_all_aux_data --data-dir ${AUX_CACHE_DIR} || oops "Could not download Satpy auxiliary data"
+
 echo "Copying Satpy auxiliary data to software bundle..."
+mkdir -p ${SATPY_DATA_DIR} || oops "Could not create polar2grid auxiliary data directory"
 # don't include large geotiff files that we don't use in P2G/G2G
-rsync -auv --exclude "*.tif" ${AUX_CACHE_DIR}/* "${SATPY_DATA_DIR}/"
+rsync -auv --exclude "*.tif" ${AUX_CACHE_DIR}/* "${SATPY_DATA_DIR}/" || oops "Could not copy Satpy auxiliary data to software bundle"
 
 # Perform extra "risky" operations to make the tarball as small as possible
 # Taken from https://jcrist.github.io/conda-docker-tips.html
@@ -149,7 +151,7 @@ if [ $MINIFY_TARBALL -ne 0 ]; then
     find . -follow -type f -name '*.a' -delete
     find . -follow -type f -name '*.pyc' -delete
     find . -follow -type f -name '*.js.map' -delete
-    find ./lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete
+    find ${PYTHON_RUNTIME_BASE}/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete
 fi
 
 # Tar up the software bundle

--- a/doc/source/_static/CSPP_Logo.png
+++ b/doc/source/_static/CSPP_Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69b128d64b866ab1f123c3165f11c594bb9877313f794ccb376ccea48f663013
+size 142577

--- a/swbundle/env.sh
+++ b/swbundle/env.sh
@@ -64,6 +64,8 @@ if [[ "${_POLAR2GRID_ENV_LOADED}" == "${METADATA_CHECKSUM}" ]]; then
     # The cviirs and crefl executables require base HDF files which by default are in the bin directory
     export ANCPATH=$POLAR2GRID_HOME/bin
     export SATPY_CONFIG_PATH=$POLAR2GRID_HOME/etc/polar2grid
+    export SATPY_DATA_DIR=$POLAR2GRID_HOME/share/polar2grid/data
+    export SATPY_DOWNLOAD_AUX=False
     export PSP_CONFIG_FILE=$POLAR2GRID_HOME/etc/polar2grid/pyspectral.yaml
     export PSP_DATA_ROOT=$POLAR2GRID_HOME/pyspectral_data
     export GSHHS_DATA_ROOT=$POLAR2GRID_HOME/gshhg_data


### PR DESCRIPTION
Satpy now provides an interface for downloading additional data files. With Polar2Grid, we don't want this to happen at runtime; we want to download everything we're going to need before hand. This PR adds the basic logic to make this work. This will likely take many iterations to get perfect so that we are only including files that we really need. For example, there are composites in Satpy that download huge geotiff files but we don't use these composites. Similarly, should we include things like the MiRS lookup tables when we bundle Geo2Grid? Probably not, but I don't like the idea of these things only being included in one project and not the other. We'll see what kind of size increases we get.