### PR TITLE
Fix default resampling parameters for VIIRS

### DIFF
--- a/etc/resampling.yaml
+++ b/etc/resampling.yaml
@@ -12,7 +12,7 @@ resampling:
     resampler: ewa
     kwargs:
       weight_delta_max: 40.0
-      weight_distance_max: 1.0
+      weight_distance_max: 2.0
   default_modis:
     area_type: swath
     sensor: modis


### PR DESCRIPTION
As pointed out in #326, VIIRS should have a fornav "d" flag of 2, but I had it as 1. This is likely a copy/paste error.