### PR TITLE
Update VIIRS crefl usage to download CMGDEM.hdf file

### DIFF
--- a/etc/composites/viirs.yaml
+++ b/etc/composites/viirs.yaml
@@ -2,10 +2,10 @@ sensor_name: visir/viirs
 
 modifiers:
   rayleigh_corrected:
-    modifier: !!python/name:satpy.composites.viirs.ReflectanceCorrector
-    dem_filename: CMGDEM.hdf
-    prerequisites: []
-    optional_prerequisites:
+    modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
+    url: "https://www.ssec.wisc.edu/~davidh/polar2grid/viirs_crefl/CMGDEM.hdf"
+    known_hash: "sha256:f33f1f867d79fff4fafe128f61c154236dd74fcc97bf418ea1437977a38d0604"
+    prerequisites:
     - name: satellite_azimuth_angle
       resolution: 742
     - name: satellite_zenith_angle
@@ -16,10 +16,10 @@ modifiers:
       resolution: 742
 
   rayleigh_corrected_iband:
-    modifier: !!python/name:satpy.composites.viirs.ReflectanceCorrector
-    dem_filename: CMGDEM.hdf
-    prerequisites: []
-    optional_prerequisites:
+    modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
+    url: "https://www.ssec.wisc.edu/~davidh/polar2grid/viirs_crefl/CMGDEM.hdf"
+    known_hash: "sha256:f33f1f867d79fff4fafe128f61c154236dd74fcc97bf418ea1437977a38d0604"
+    prerequisites:
     - name: satellite_azimuth_angle
       resolution: 371
     - name: satellite_zenith_angle


### PR DESCRIPTION
This depends on newly added Satpy functionality. The Modifier in Satpy now downloads the CMGDEM.hdf file instead of defaulting to all 0s for the elevation dataset (if it can't find the file). This PR uses that functionality as well as the improved handling of putting a hard requirement on the angle datasets (previously optional which could cause issues in specific situations).