### PR TITLE
Fix error when sourcing bundle environment script

### DIFF
--- a/swbundle/env.sh
+++ b/swbundle/env.sh
@@ -31,7 +31,14 @@
 
 # where are we?
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+while [ -h "$SOURCE" ]; do
+    NEWSRC="$(readlink "$SOURCE")"
+    if [ ! -e "$NEWSRC" ]; then
+        # probably a relative link
+        NEWSRC="$(cd $(dirname "$SOURCE"); pwd)/$NEWSRC"
+    fi
+    SOURCE=$NEWSRC
+done
 THIS_SCRIPT_HOME="$( cd -P "$( dirname "$SOURCE" )" && cd .. && pwd )"
 P2G_CONDA_BASE="${THIS_SCRIPT_HOME}/libexec/python_runtime"
 P2G_METADATA="${P2G_CONDA_BASE}/lib/python*/site-packages/polar2grid-*.dist-info/METADATA"


### PR DESCRIPTION
 @kathys pointed out that doing `source $POLAR2GRID_HOME/bin/polar2grid_env.sh` fails in the latest tarball. I've added this to #326. The main issue is that the "real" file is `env.sh` and `polar2grid_env.sh` is just a relative softlink pointing to `env.sh`. The "magic" bash to locate the true location of the current script was not smart enough to handle this relative softlink situation so the rest of the script was trying to use an invalid location. This PR fixes that.