### PR TITLE
Add satpy-compatible flat binary file writer

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include docs/source *
+recursive-include polar2grid/tests/etc *
 include polar2grid/core/rescale_configs/*.ini
 include polar2grid/grids/grids.conf
 include polar2grid/awips/awips_grids/grids.conf

--- a/build_environment.yml
+++ b/build_environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - pykdtree
   - pyorbital
   - pyproj
-  - pyresample>=1.18.1
+  - pyresample>=1.19.0
   - pyshp
   - pyspectral
   - python=3.8

--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -7,8 +7,6 @@
 BASE_P2G_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PY_DIR="$BASE_P2G_DIR"
 BUNDLE_SCRIPTS_DIR="$BASE_P2G_DIR"/swbundle
-VCREFL_DIR="$BASE_P2G_DIR"/viirs_crefl
-MCREFL_DIR="$BASE_P2G_DIR"/modis_crefl
 CACHE_DIR="/tmp"
 
 oops() {
@@ -74,30 +72,6 @@ unzip gshhg-shp-2.3.6.zip || oops "Could not unpack GSHHG shapefiles"
 rm gshhg-shp-2.3.6.zip || oops "Could not delete the GSHHG zip file"
 chmod 444 `find . -type f` || oops "Could not make GSHHG shapefiles readable by everyone"
 popd
-
-# Create the VIIRS CREFL utilities
-#echo "Getting prebuilt VIIRS CREFL binaries..."
-#cd "$VCREFL_DIR"
-#make clean
-#make prebuilt || oops "Couldn't get prebuilt VIIRS CREFL binaries"
-#chmod a+x cviirs
-#chmod a+x h5SDS_transfer_rename
-#mv cviirs "$SB_NAME"/bin/
-#mv h5SDS_transfer_rename "$SB_NAME"/bin/
-#mv CMGDEM.hdf "$SB_NAME"/bin/
-#cp run_viirs_crefl.sh "$SB_NAME"/bin/
-#chmod a+x "$SB_NAME"/bin/run_viirs_crefl.sh
-
-# Create the MODIS CREFL utilities
-#echo "Getting prebuilt MODIS CREFL binaries..."
-#cd "$MCREFL_DIR"
-#make clean
-#make prebuilt || oops "Couldn't get prebuilt MODIS CREFL binaries"
-#chmod a+x crefl
-#mv crefl "$SB_NAME"/bin/
-#mv tbase.hdf "$SB_NAME"/bin/
-#cp run_modis_crefl.sh "$SB_NAME"/bin/
-#chmod a+x "$SB_NAME"/bin/run_modis_crefl.sh
 
 echo "Copying bash scripts to software bundle bin"
 cd "$SB_NAME"

--- a/etc/writers/binary.yaml
+++ b/etc/writers/binary.yaml
@@ -1,0 +1,5 @@
+writer:
+  name: binary
+  description: Generic Flat Binary File Writer
+  writer: !!python/name:polar2grid.writers.binary.FlatBinaryWriter
+  filename: "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat"

--- a/polar2grid/core/dtype.py
+++ b/polar2grid/core/dtype.py
@@ -40,7 +40,7 @@ Functions that handle polar2grid data types.
 """
 __docformat__ = "restructuredtext en"
 
-import numpy
+import numpy as np
 
 import sys
 import logging
@@ -59,30 +59,30 @@ DTYPE_FLOAT32 = "real4"
 DTYPE_FLOAT64 = "real8"
 
 NUMPY_DTYPE_STRS = [
-    'uint8',
-    'uint16',
-    'uint32',
-    'uint64',
-    'int8',
-    'int16',
-    'int32',
-    'int64',
-    'float32',
-    'float64',
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "float32",
+    "float64",
 ]
 
-# Map data type to numpy type for conversion
+# Map data type to np type for conversion
 str2dtype = {
-    DTYPE_UINT8: numpy.uint8,
-    DTYPE_UINT16: numpy.uint16,
-    DTYPE_UINT32: numpy.uint32,
-    DTYPE_UINT64: numpy.uint64,
-    DTYPE_INT8: numpy.int8,
-    DTYPE_INT16: numpy.int16,
-    DTYPE_INT32: numpy.int32,
-    DTYPE_INT64: numpy.int64,
-    DTYPE_FLOAT32: numpy.float32,
-    DTYPE_FLOAT64: numpy.float64
+    DTYPE_UINT8: np.uint8,
+    DTYPE_UINT16: np.uint16,
+    DTYPE_UINT32: np.uint32,
+    DTYPE_UINT64: np.uint64,
+    DTYPE_INT8: np.int8,
+    DTYPE_INT16: np.int16,
+    DTYPE_INT32: np.int32,
+    DTYPE_INT64: np.int64,
+    DTYPE_FLOAT32: np.float32,
+    DTYPE_FLOAT64: np.float64,
 }
 dtype2str = dict((v, k) for k, v in str2dtype.items())
 
@@ -90,16 +90,16 @@ dtype2str = dict((v, k) for k, v in str2dtype.items())
 # Since float32 is polar2grid's intermediate type, float32 and float64 don't
 # get clipped
 dtype2range = {
-    DTYPE_UINT8: (0, 2**8-1),
-    DTYPE_UINT16: (0, 2**16-1),
-    DTYPE_UINT32: (0, 2**32-1),
-    DTYPE_UINT64: (0, 2**64-1),
-    DTYPE_INT8: (-1*(2**7), 2**7-1),
-    DTYPE_INT16: (-1*(2**15), 2**15-1),
-    DTYPE_INT32: (-1*(2**31), 2**31-1),
-    DTYPE_INT64: (-1*(2**63), 2**63-1),
+    DTYPE_UINT8: (0, 2 ** 8 - 1),
+    DTYPE_UINT16: (0, 2 ** 16 - 1),
+    DTYPE_UINT32: (0, 2 ** 32 - 1),
+    DTYPE_UINT64: (0, 2 ** 64 - 1),
+    DTYPE_INT8: (-1 * (2 ** 7), 2 ** 7 - 1),
+    DTYPE_INT16: (-1 * (2 ** 15), 2 ** 15 - 1),
+    DTYPE_INT32: (-1 * (2 ** 31), 2 ** 31 - 1),
+    DTYPE_INT64: (-1 * (2 ** 63), 2 ** 63 - 1),
     DTYPE_FLOAT32: None,
-    DTYPE_FLOAT64: None
+    DTYPE_FLOAT64: None,
 }
 
 
@@ -113,12 +113,12 @@ def normalize_dtype_string(dtype_str):
 
 
 def str_to_dtype(dtype_str):
-    if numpy.issubclass_(dtype_str, numpy.number):
-        # if they gave us a numpy dtype
+    if np.issubclass_(dtype_str, np.number):
+        # if they gave us a np dtype
         return dtype_str
-    elif isinstance(dtype_str, str) and hasattr(numpy, dtype_str):
-        # they gave us the numpy name of the dtype
-        return getattr(numpy, dtype_str)
+    elif isinstance(dtype_str, str) and hasattr(np, dtype_str):
+        # they gave us the np name of the dtype
+        return getattr(np, dtype_str)
 
     try:
         return str2dtype[dtype_str]
@@ -132,9 +132,9 @@ def dtype_to_str(numpy_dtype):
         return normalize_dtype_string(numpy_dtype)
 
     try:
-        return dtype2str[numpy.dtype(numpy_dtype).type]
+        return dtype2str[np.dtype(numpy_dtype).type]
     except KeyError:
-        raise ValueError("Unsupported numpy data type: %r" % (numpy_dtype,))
+        raise ValueError("Unsupported np data type: %r" % (numpy_dtype,))
 
 
 def convert_to_data_type(data, data_type):
@@ -153,17 +153,13 @@ def convert_to_data_type(data, data_type):
 
 
 def clip_to_data_type(data, data_type):
-    if not isinstance(data_type, str):
-        data_type = dtype_to_str(data_type)
-    if data_type not in str2dtype:
-        log.error("Unknown data_type '%s', don't know how to convert data" % (data_type,))
-        raise ValueError("Unknown data_type '%s', don't know how to convert data" % (data_type,))
-
-    rmin, rmax = dtype2range[data_type]
+    if np.issubdtype(np.dtype(data_type), np.floating):
+        return data
+    info = np.iinfo(data_type)
+    rmin = info.min
+    rmax = info.max
     log.debug("Clipping data to a %d - %d data range" % (rmin, rmax))
-    numpy.clip(data, rmin, rmax, out=data)
-
-    return convert_to_data_type(data, data_type)
+    return data.clip(rmin, rmax)
 
 
 def int_or_float(val):

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -121,9 +121,7 @@ def write_scene(scn, writers, writer_args, datasets, to_save=None):
 
     for writer_name in writers:
         wargs = writer_args[writer_name]
-        res = scn.save_datasets(
-            writer=writer_name, compute=False, datasets=datasets, **wargs
-        )
+        res = scn.save_datasets(writer=writer_name, compute=False, datasets=datasets, **wargs)
         if isinstance(res[0], (tuple, list)):
             # list of (dask-array, file-obj) tuples
             to_save.extend(zip(*res))
@@ -141,7 +139,7 @@ def _convert_writer_name(writer_name: str) -> str:
     return WRITER_ALIASES.get(writer_name, writer_name)
 
 
-def add_scene_argument_groups(parser, is_polar2grid=False):
+def _supported_readers(is_polar2grid: bool = False) -> list[str]:
     if is_polar2grid:
         readers = [
             "acspo",
@@ -157,16 +155,23 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
             "viirs_sdr",
             "virr_l1b",
         ]
-        filter_dn_products = 0.1
-        filter_doc = " and is enabled by default."
     else:
         readers = [
             "abi_l1b",
             "ahi_hrit",
             "ahi_hsd",
         ]
+    return readers
+
+
+def add_scene_argument_groups(parser, is_polar2grid=False):
+    if is_polar2grid:
+        filter_dn_products = 0.1
+        filter_doc = " and is enabled by default."
+    else:
         filter_dn_products = False
         filter_doc = ", but is disabled by default."
+    readers = _supported_readers(is_polar2grid)
 
     group_1 = parser.add_argument_group(title="Reading")
     group_1.add_argument(
@@ -176,8 +181,7 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
         dest="readers",
         metavar="READER",
         type=_convert_reader_name,
-        help="Name of reader used to read provided files. "
-        "Supported readers: " + ", ".join(readers),
+        help="Name of reader used to read provided files. " "Supported readers: " + ", ".join(readers),
     )
     group_1.add_argument(
         "-f",
@@ -193,9 +197,7 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
         "of files from the other arguments. "
         "arguments (ex. '%(prog)s ... -- /path/to/files*')",
     )
-    group_1.add_argument(
-        "filenames", nargs="*", action="extend", help=argparse.SUPPRESS
-    )
+    group_1.add_argument("filenames", nargs="*", action="extend", help=argparse.SUPPRESS)
     # help="Alternative to '-f' flag. Use two hyphens (--) "
     #      "to separate these files from other command line "
     #      "arguments (ex. '%(prog)s ... -- /path/to/files*')")
@@ -248,7 +250,22 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
     return (group_1,)
 
 
-def add_writer_argument_groups(parser):
+def _supported_writers(is_polar2grid: bool = False) -> list[str]:
+    if is_polar2grid:
+        writers = [
+            "geotiff",
+            "awips_tiled",
+            "binary",
+        ]
+    else:
+        writers = [
+            "geotiff",
+        ]
+    return writers
+
+
+def add_writer_argument_groups(parser, is_polar2grid=False):
+    writers = _supported_writers(is_polar2grid)
     group_1 = parser.add_argument_group(title="Writing")
     group_1.add_argument(
         "-w",
@@ -259,7 +276,8 @@ def add_writer_argument_groups(parser):
         metavar="WRITER",
         help="Writers to save datasets with. Multiple writers "
         "can be provided by specifying '-w' multiple "
-        "times (ex. '-w geotiff -w awips_tiled').",
+        "times (ex. '-w geotiff -w awips_tiled'). "
+        "Supported writers: " + ", ".join(writers),
     )
     return (group_1,)
 
@@ -338,16 +356,14 @@ def add_resample_argument_groups(parser, is_polar2grid=False):
             "--grids",
             default=None,
             nargs="*",
-            help="Area definition to resample to. Empty means "
-            'no resampling (default: "MAX")',
+            help="Area definition to resample to. Empty means " 'no resampling (default: "MAX")',
         )
     # shared options
     group_1.add_argument(
         "--grid-coverage",
         default=0.1,
         type=float,
-        help="Fraction of target grid that must contain "
-        "data to continue processing product.",
+        help="Fraction of target grid that must contain " "data to continue processing product.",
     )
     group_1.add_argument(
         "--cache-dir",
@@ -401,11 +417,7 @@ def _retitle_optional_arguments(parser):
 def _add_component_parser_args(
     parser: argparse.ArgumentParser, component_type: str, component_names: list[str]
 ) -> list:
-    _get_args_func = (
-        get_writer_parser_function
-        if component_type == "writers"
-        else get_reader_parser_function
-    )
+    _get_args_func = get_writer_parser_function if component_type == "writers" else get_reader_parser_function
     subgroups = []
     for component_name in component_names:
         parser_func = _get_args_func(component_name)
@@ -421,9 +433,7 @@ def _args_to_dict(args, group_actions, exclude=None):
     if exclude is None:
         exclude = []
     return {
-        ga.dest: getattr(args, ga.dest)
-        for ga in group_actions
-        if hasattr(args, ga.dest) and ga.dest not in exclude
+        ga.dest: getattr(args, ga.dest) for ga in group_actions if hasattr(args, ga.dest) and ga.dest not in exclude
     }
 
 
@@ -457,9 +467,7 @@ def _parse_writer_args(
         writer_args[writer_name] = wargs
         # get default output filename
         if "filename" in wargs and wargs["filename"] is None:
-            wargs["filename"] = get_default_output_filename(
-                reader_names[0], writer_name
-            )
+            wargs["filename"] = get_default_output_filename(reader_names[0], writer_name)
     return writer_args
 
 
@@ -527,9 +535,7 @@ def main(argv=sys.argv[1:]):
     import argparse
 
     add_polar2grid_config_paths()
-    USE_POLAR2GRID_DEFAULTS = bool(
-        int(os.environ.setdefault("USE_POLAR2GRID_DEFAULTS", "1"))
-    )
+    USE_POLAR2GRID_DEFAULTS = bool(int(os.environ.setdefault("USE_POLAR2GRID_DEFAULTS", "1")))
     BINARY_NAME = "polar2grid" if USE_POLAR2GRID_DEFAULTS else "geo2grid"
 
     prog = os.getenv("PROG_NAME", sys.argv[0])
@@ -555,12 +561,9 @@ basic processing with limited products:
         dest="verbosity",
         action="count",
         default=0,
-        help="each occurrence increases verbosity 1 level through "
-        "ERROR-WARNING-INFO-DEBUG (default INFO)",
+        help="each occurrence increases verbosity 1 level through " "ERROR-WARNING-INFO-DEBUG (default INFO)",
     )
-    parser.add_argument(
-        "-l", "--log", dest="log_fn", default=None, help="specify the log filename"
-    )
+    parser.add_argument("-l", "--log", dest="log_fn", default=None, help="specify the log filename")
     parser.add_argument(
         "--progress",
         action="store_true",
@@ -590,16 +593,10 @@ basic processing with limited products:
         "--list-products-all",
         dest="list_products_all",
         action="store_true",
-        help="List available {} products and custom/Satpy products and exit".format(
-            BINARY_NAME
-        ),
+        help="List available {} products and custom/Satpy products and exit".format(BINARY_NAME),
     )
-    reader_group = add_scene_argument_groups(
-        parser, is_polar2grid=USE_POLAR2GRID_DEFAULTS
-    )[0]
-    resampling_group = add_resample_argument_groups(
-        parser, is_polar2grid=USE_POLAR2GRID_DEFAULTS
-    )[0]
+    reader_group = add_scene_argument_groups(parser, is_polar2grid=USE_POLAR2GRID_DEFAULTS)[0]
+    resampling_group = add_resample_argument_groups(parser, is_polar2grid=USE_POLAR2GRID_DEFAULTS)[0]
     writer_group = add_writer_argument_groups(parser)[0]
     argv_without_help = [x for x in argv if x not in ["-h", "--help"]]
 
@@ -620,16 +617,13 @@ basic processing with limited products:
         parser.exit(
             1,
             "\nERROR: Reader must be provided (-r flag).\n"
-            "Supported readers:\n\t{}\n".format(
-                "\n\t".join(["abi_l1b", "ahi_hsd", "hrit_ahi"])
-            ),
+            "Supported readers:\n\t{}\n".format("\n\t".join(_supported_readers(USE_POLAR2GRID_DEFAULTS))),
         )
     elif len(args.readers) > 1:
         parser.print_usage()
         parser.exit(
             1,
-            "\nMultiple readers is not currently supported. Got:\n\t"
-            "{}\n".format("\n\t".join(args.readers)),
+            "\nMultiple readers is not currently supported. Got:\n\t" "{}\n".format("\n\t".join(args.readers)),
         )
         return -1
     if args.writers is None:
@@ -637,19 +631,15 @@ basic processing with limited products:
         parser.exit(
             1,
             "\nERROR: Writer must be provided (-w flag) with one or more writer.\n"
-            "Supported writers:\n\t{}\n".format("\n\t".join(["geotiff"])),
+            "Supported writers:\n\t{}\n".format("\n\t".join(_supported_writers(USE_POLAR2GRID_DEFAULTS))),
         )
 
     reader_args = _args_to_dict(args, reader_group._group_actions)
     reader_names = reader_args.pop("readers")
-    scene_creation, load_args = _get_scene_init_load_args(
-        args, reader_args, reader_names, reader_subgroups
-    )
+    scene_creation, load_args = _get_scene_init_load_args(args, reader_args, reader_names, reader_subgroups)
     resample_args = _args_to_dict(args, resampling_group._group_actions)
     writer_args = _args_to_dict(args, writer_group._group_actions)
-    writer_specific_args = _parse_writer_args(
-        writer_args["writers"], writer_subgroups, reader_names, args
-    )
+    writer_specific_args = _parse_writer_args(writer_args["writers"], writer_subgroups, reader_names, args)
     writer_args.update(writer_specific_args)
 
     if not args.filenames:
@@ -662,9 +652,7 @@ basic processing with limited products:
         rename_log = True
         args.log_fn = glue_name + "_fail.log"
     levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
-    setup_logging(
-        console_level=levels[min(3, args.verbosity)], log_filename=args.log_fn
-    )
+    setup_logging(console_level=levels[min(3, args.verbosity)], log_filename=args.log_fn)
     logging.getLogger("rasterio").setLevel(levels[min(2, args.verbosity)])
     sys.excepthook = create_exc_handler(LOG.name)
     if levels[min(3, args.verbosity)] > logging.DEBUG:
@@ -682,31 +670,21 @@ basic processing with limited products:
     try:
         scn = Scene(**scene_creation)
     except ValueError as e:
-        LOG.error(
-            "{} | Enable debug message (-vvv) or see log file for details.".format(
-                str(e)
-            )
-        )
+        LOG.error("{} | Enable debug message (-vvv) or see log file for details.".format(str(e)))
         LOG.debug("Further error information: ", exc_info=True)
         return -1
     except OSError:
-        LOG.error(
-            "Could not open files. Enable debug message (-vvv) or see log file for details."
-        )
+        LOG.error("Could not open files. Enable debug message (-vvv) or see log file for details.")
         LOG.debug("Further error information: ", exc_info=True)
         return -1
 
     # Rename the log file
     if rename_log:
-        rename_log_file(
-            glue_name + scn.attrs["start_time"].strftime("_%Y%m%d_%H%M%S.log")
-        )
+        rename_log_file(glue_name + scn.attrs["start_time"].strftime("_%Y%m%d_%H%M%S.log"))
 
     # Load the actual data arrays and metadata (lazy loaded as dask arrays)
     LOG.info("Loading product metadata from files...")
-    reader_info = ReaderProxyBase.from_reader_name(
-        scene_creation["reader"], scn, load_args["products"]
-    )
+    reader_info = ReaderProxyBase.from_reader_name(scene_creation["reader"], scn, load_args["products"])
     if args.list_products or args.list_products_all:
         _print_list_products(reader_info, p2g_only=not args.list_products_all)
         return 0
@@ -740,7 +718,7 @@ basic processing with limited products:
         areas_to_resample,
         preserve_resolution=args.preserve_resolution,
         is_polar2grid=USE_POLAR2GRID_DEFAULTS,
-        **resample_args
+        **resample_args,
     )
     for scene_to_save, products_to_save in scenes_to_save:
         overwrite_platform_name_with_aliases(scene_to_save)

--- a/polar2grid/tests/__init__.py
+++ b/polar2grid/tests/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-# Copyright (C) 2014 Space Science and Engineering Center (SSEC),
+# Copyright (C) 2014-2021 Space Science and Engineering Center (SSEC),
 #  University of Wisconsin-Madison.
 #
 #     This program is free software: you can redistribute it and/or modify
@@ -20,20 +20,4 @@
 # satellite observation data, remaps it, and writes it to a file format for
 # input into another program.
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
-#
-#     Written by David Hoese    December 2014
-#     University of Wisconsin-Madison
-#     Space Science and Engineering Center
-#     1225 West Dayton Street
-#     Madison, WI  53706
-#     david.hoese@ssec.wisc.edu
-"""Tests for polar2grid.
-
-:author:       David Hoese (davidh)
-:contact:      david.hoese@ssec.wisc.edu
-:organization: Space Science and Engineering Center (SSEC)
-:copyright:    Copyright (c) 2014 University of Wisconsin SSEC. All rights reserved.
-:date:         Dec 2014
-:license:      GNU GPLv3
-
-"""
+"""Tests for polar2grid."""

--- a/polar2grid/tests/etc/enhancements/generic.yaml
+++ b/polar2grid/tests/etc/enhancements/generic.yaml
@@ -1,0 +1,7 @@
+enhancements:
+  test_arange_default:
+    standard_name: test_arange
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 500.}

--- a/polar2grid/tests/test_writers/__init__.py
+++ b/polar2grid/tests/test_writers/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-# Copyright (C) 2014 Space Science and Engineering Center (SSEC),
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
 #  University of Wisconsin-Madison.
 #
 #     This program is free software: you can redistribute it and/or modify
@@ -20,20 +20,4 @@
 # satellite observation data, remaps it, and writes it to a file format for
 # input into another program.
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
-#
-#     Written by David Hoese    December 2014
-#     University of Wisconsin-Madison
-#     Space Science and Engineering Center
-#     1225 West Dayton Street
-#     Madison, WI  53706
-#     david.hoese@ssec.wisc.edu
-"""Run tests for polar2grid from the command line.
-
-:author:       David Hoese (davidh)
-:contact:      david.hoese@ssec.wisc.edu
-:organization: Space Science and Engineering Center (SSEC)
-:copyright:    Copyright (c) 2014 University of Wisconsin SSEC. All rights reserved.
-:date:         Dec 2014
-:license:      GNU GPLv3
-
-"""
+"""Tests for polar2grid-specific writers."""

--- a/polar2grid/tests/test_writers/test_binary.py
+++ b/polar2grid/tests/test_writers/test_binary.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Tests for the binary writer."""
+
+import os
+from datetime import datetime
+from unittest import mock
+
+import satpy
+from satpy import Scene
+import xarray as xr
+import dask.array as da
+import numpy as np
+import pytest
+
+
+TEST_ETC_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "etc"))
+
+
+def _int_min_max(dtype):
+    info = np.iinfo(dtype)
+    return info.min, info.max
+
+
+def _min_max_for_two_dtypes(src_dtype, dst_dtype):
+    src_is_int = not np.issubdtype(src_dtype, np.floating)
+    dst_is_int = not np.issubdtype(dst_dtype, np.floating)
+    if src_is_int and dst_is_int:
+        smin, smax = _int_min_max(src_dtype)
+        dmin, dmax = _int_min_max(dst_dtype)
+        return max(smin, dmin), min(smax, dmax)
+    elif src_is_int:
+        return _int_min_max(src_dtype)
+    return _int_min_max(dst_dtype)
+
+
+def _create_fake_data_arr(shape=(100, 50), dims=("y", "x"), dtype=np.float64):
+    area_mock = mock.MagicMock()
+    area_mock.area_id = "fake_area"
+    attrs = {
+        "name": "fake_name",
+        "p2g_name": "fake_p2g_name",
+        "platform_name": "NOAA-20",
+        "sensor": "viirs",
+        "start_time": datetime(2021, 1, 1, 12, 0, 0),
+        "end_time": datetime(2021, 1, 1, 12, 10, 0),
+        "area": area_mock,
+        "standard_name": "test_arange",
+    }
+    data = np.arange(np.prod(shape), dtype=np.float32)
+    if not np.issubdtype(dtype, np.floating):
+        data = np.clip(data, *_int_min_max(dtype))
+        attrs["_FillValue"] = 0
+    data = data.astype(dtype)
+    data = da.from_array(data, chunks=10).reshape(shape)
+    data_arr = xr.DataArray(data, attrs=attrs, dims=dims)
+    return data_arr
+
+
+class TestBinaryWriter:
+    """Test the binary writer."""
+
+    def setup_method(self):
+        """Add P2G configs to the Satpy path."""
+        from polar2grid.glue import add_polar2grid_config_paths
+
+        self._old_path = satpy.config.get("config_path")
+        add_polar2grid_config_paths()
+        # add test specific configs
+        curr_path = satpy.config.get("config_path")
+        satpy.config.set(config_path=[TEST_ETC_DIR] + curr_path)
+
+    def teardown_method(self):
+        """Reset Satpy config path back to the original value."""
+        satpy.config.set(config_path=self._old_path)
+
+    @pytest.mark.parametrize("enhance", [True, False])
+    @pytest.mark.parametrize("dst_dtype", [None, np.float32, np.float64, np.uint8])
+    @pytest.mark.parametrize("src_dtype", [np.float32, np.float64, np.uint8])
+    def test_basic_write(self, tmpdir, src_dtype, dst_dtype, enhance):
+        """Test writing data to disk."""
+        src_data_arr = _create_fake_data_arr(dtype=src_dtype)
+        scn = Scene()
+        scn[src_data_arr.attrs["name"]] = src_data_arr
+        scn.save_datasets(writer="binary", base_dir=str(tmpdir), dtype=dst_dtype, enhance=enhance)
+        exp_fn = tmpdir.join("noaa-20_viirs_fake_p2g_name_20210101_120000_fake_area.dat")
+
+        if dst_dtype is None:
+            dst_dtype = src_dtype
+        assert os.path.isfile(exp_fn)
+        data = np.memmap(str(exp_fn), mode="r", dtype=dst_dtype)
+        exp_data = self._generate_expected_output(src_data_arr, dst_dtype, enhance)
+        np.testing.assert_allclose(data, exp_data, atol=2e-7)
+
+    def _generate_expected_output(self, src_data_arr, dst_dtype, enhance):
+        src_dtype = src_data_arr.dtype
+        exp_data = src_data_arr.values.astype(np.float).ravel()
+        if enhance:
+            exp_data = exp_data / 500.0  # see polar2grid/tests/etc/enhancements/generic.yaml
+            if not np.issubdtype(dst_dtype, np.floating):
+                rmin, rmax = _int_min_max(dst_dtype)
+                exp_data = exp_data * (rmax - rmin) + rmin
+            exp_data = exp_data.astype(dst_dtype)
+        elif not np.issubdtype(dst_dtype, np.floating) or not np.issubdtype(src_dtype, np.floating):
+            rmin, rmax = _min_max_for_two_dtypes(src_dtype, dst_dtype)
+            exp_data = np.clip(exp_data, rmin, rmax)
+        return exp_data

--- a/polar2grid/tests/test_writers/test_binary.py
+++ b/polar2grid/tests/test_writers/test_binary.py
@@ -114,7 +114,7 @@ class TestBinaryWriter:
 
     def _generate_expected_output(self, src_data_arr, dst_dtype, enhance):
         src_dtype = src_data_arr.dtype
-        exp_data = src_data_arr.values.astype(np.float64).ravel()
+        exp_data = src_data_arr.values.astype(np.float32).ravel()
         if enhance:
             exp_data = exp_data / 500.0  # see polar2grid/tests/etc/enhancements/generic.yaml
             if not np.issubdtype(dst_dtype, np.floating):

--- a/polar2grid/tests/test_writers/test_binary.py
+++ b/polar2grid/tests/test_writers/test_binary.py
@@ -114,7 +114,7 @@ class TestBinaryWriter:
 
     def _generate_expected_output(self, src_data_arr, dst_dtype, enhance):
         src_dtype = src_data_arr.dtype
-        exp_data = src_data_arr.values.astype(np.float).ravel()
+        exp_data = src_data_arr.values.astype(np.float64).ravel()
         if enhance:
             exp_data = exp_data / 500.0  # see polar2grid/tests/etc/enhancements/generic.yaml
             if not np.issubdtype(dst_dtype, np.floating):

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -20,7 +20,14 @@
 # satellite observation data, remaps it, and writes it to a file format for
 # input into another program.
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
-"""The Binary writer writes band data to a flat binary file."""
+"""The Binary writer writes band data to a flat binary file.
+
+By default it enhances the data based on the enhancement configuration file
+and then saves the data to a flat binary file of the same data type. A different
+output type can be specified as well as the ``--no-enhance`` command line flag to
+write the "raw" band data.
+
+"""
 
 from __future__ import annotations
 

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+# University of Wisconsin-Madison.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""The Binary writer writes band data to a flat binary file."""
+
+from __future__ import annotations
+
+import logging
+
+from polar2grid.core.script_utils import NumpyDtypeList
+from polar2grid.core.dtype import NUMPY_DTYPE_STRS, str_to_dtype, int_or_float, dtype_to_str, clip_to_data_type
+
+from satpy.writers import ImageWriter, get_enhanced_image
+import xarray as xr
+import numpy as np
+import dask.array as da
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_FILENAMES = {
+    None: "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat"
+}
+
+
+class FlatBinaryWriter(ImageWriter):
+    """Write data to disk as flat binary files."""
+
+    def save_dataset(
+        self, dataset, filename=None, fill_value=None, overlay=None, decorate=None, compute=True, **kwargs
+    ):
+        """Save the ``dataset`` to a given ``filename``.
+
+        This method creates an enhanced image using :func:`get_enhanced_image`.
+        The image is then passed to :meth:`save_image`. See both of these
+        functions for more details on the arguments passed to this method.
+
+        """
+        img = get_enhanced_image(
+            dataset.squeeze(), enhance=self.enhancer, overlay=overlay, decorate=decorate, fill_value=fill_value
+        )
+        kwargs["dtype"] = kwargs.get("dtype") or dataset.dtype
+        return self.save_image(img, filename=filename, compute=compute, fill_value=fill_value, **kwargs)
+
+    def save_image(self, img, filename=None, compute=True, dtype=None, fill_value=None, **kwargs):
+        filename = filename or self.get_filename(
+            data_type=dtype_to_str(dtype), rows=img.data.shape[0], columns=img.data.shape[1], **img.data.attrs
+        )
+
+        data = self._prep_data(img.data, dtype, fill_value)
+
+        logger.info("Saving product %s to binary file %s", img.data.attrs["p2g_name"], filename)
+        dst = np.memmap(filename, shape=img.data.shape, dtype=dtype, mode="w+")
+        if compute:
+            da.store(data, dst)
+            return
+        return [[data], [dst]]
+
+    def _prep_data(self, data: xr.DataArray, dtype: np.dtype, fill_value) -> da.Array:
+        fill = data.attrs.get("_FillValue", np.nan)
+        if fill_value is None:
+            fill_value = fill
+        final_data = clip_to_data_type(data.data, dtype)
+        if self.enhancer and np.issubdtype(data.dtype, np.floating) and not np.issubdtype(dtype, np.floating):
+            # going from float -> int and the data was enhanced
+            # scale the data to fit the integer dtype
+            rmin, rmax = np.iinfo(dtype).min, np.iinfo(dtype).max
+            final_data = final_data * (rmax - rmin) + rmin
+
+        same_fill = np.isnan(fill) and np.isnan(fill_value) or fill == fill_value
+        if data.dtype == dtype and same_fill:
+            return final_data
+
+        final_data = final_data.astype(dtype)
+        if same_fill:
+            return final_data
+
+        fill_mask = np.isnan(final_data) if np.isnan(fill) else final_data == fill
+        final_data = da.where(fill_mask, fill_value, final_data)
+        return final_data
+
+
+def add_writer_argument_groups(parser, group=None):
+    if group is None:
+        group = parser.add_argument_group(title="Binary Writer")
+
+    group.add_argument(
+        "--output-filename",
+        dest="filename",
+        help="Custom file pattern to save dataset to",
+    )
+    group.add_argument(
+        "--dtype",
+        choices=NumpyDtypeList(NUMPY_DTYPE_STRS),
+        type=str_to_dtype,
+        help="Data type of the output file (8-bit unsigned " "integer by default - uint8)",
+    )
+    group.add_argument(
+        "--no-enhance",
+        dest="enhance",
+        action="store_false",
+        help="Don't try to enhance the data before saving it",
+    )
+    group.add_argument(
+        "--fill-value",
+        dest="fill_value",
+        type=int_or_float,
+        help="Instead of an alpha channel fill invalid "
+        "values with this value. Turns LA or RGBA "
+        "images in to L or RGB images respectively.",
+    )
+    return group, None

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -85,12 +85,13 @@ class FlatBinaryWriter(ImageWriter):
         fill = data.attrs.get("_FillValue", np.nan)
         if fill_value is None:
             fill_value = fill
-        final_data = clip_to_data_type(data.data, dtype)
+        final_data = data.data
         if self.enhancer and np.issubdtype(data.dtype, np.floating) and not np.issubdtype(dtype, np.floating):
             # going from float -> int and the data was enhanced
             # scale the data to fit the integer dtype
             rmin, rmax = np.iinfo(dtype).min, np.iinfo(dtype).max
             final_data = final_data * (rmax - rmin) + rmin
+        final_data = clip_to_data_type(final_data, dtype)
 
         same_fill = np.isnan(fill) and np.isnan(fill_value) or fill == fill_value
         if data.dtype == dtype and same_fill:

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -40,6 +40,7 @@ as transparent in most image viewers.
 import os
 import logging
 from polar2grid.core.dtype import NUMPY_DTYPE_STRS, str_to_dtype, int_or_float
+from polar2grid.core.script_utils import NumpyDtypeList
 
 LOG = logging.getLogger(__name__)
 
@@ -48,21 +49,8 @@ DEFAULT_OUTPUT_FILENAMES = {
     None: "{platform_name!u}_{sensor!u}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
     "abi_l1b": "{platform_name!u}_{sensor!u}_{observation_type}{scene_abbr}_"
     "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_"
-    "{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+    "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_" "{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
 }
-
-
-class NumpyDtypeList(list):
-    """Magic list to allow dtype objects to match string versions of themselves."""
-
-    def __contains__(self, item):
-        if super(NumpyDtypeList, self).__contains__(item):
-            return True
-        try:
-            return super(NumpyDtypeList, self).__contains__(item().dtype.name)
-        except AttributeError:
-            return False
 
 
 def add_writer_argument_groups(parser, group=None):
@@ -79,8 +67,7 @@ def add_writer_argument_groups(parser, group=None):
         "--dtype",
         choices=NumpyDtypeList(NUMPY_DTYPE_STRS),
         type=str_to_dtype,
-        help="Data type of the output file (8-bit unsigned "
-        "integer by default - uint8)",
+        help="Data type of the output file (8-bit unsigned " "integer by default - uint8)",
     )
     group.add_argument(
         "--no-enhance",
@@ -102,12 +89,8 @@ def add_writer_argument_groups(parser, group=None):
         help="File compression algorithm (DEFLATE, LZW, NONE, etc)",
     )
     group.add_argument("--tiled", action="store_true", help="Create tiled geotiffs")
-    group.add_argument(
-        "--blockxsize", default=SUPPRESS, type=int, help="Set tile block X size"
-    )
-    group.add_argument(
-        "--blockysize", default=SUPPRESS, type=int, help="Set tile block Y size"
-    )
+    group.add_argument("--blockxsize", default=SUPPRESS, type=int, help="Set tile block X size")
+    group.add_argument("--blockysize", default=SUPPRESS, type=int, help="Set tile block Y size")
     group.add_argument(
         "--gdal-num-threads",
         dest="num_threads",


### PR DESCRIPTION
This re-adds (ports?) the binary writer to work with Polar2Grid 3.0 by making a satpy-compatible writer. This is an interesting conversion because I kind of disagree with the way the original writer was done. It had a few special cases for floating point data and for fill values. This version of the writer is a little more predictable and I *think* it mostly behaves the same. It now *always* enhances (old language: rescales) the data regardless of input or output data type (dtype). This *might* require some existing users (the 1 or 2 that there are, I assume) to add `--no-enhance` to their commands.