### PR TITLE
Add new MiRS integration tests

### DIFF
--- a/integration_tests/features/polar2grid.feature
+++ b/integration_tests/features/polar2grid.feature
@@ -35,6 +35,13 @@ Feature: Test polar2grid output images
       | polar2grid.sh -r viirs_sdr -w geotiff -vv -p adaptive_dnb dynamic_dnb -f                     | viirs_sdr_night/input/test1 | viirs_sdr_night/output/test1 |
       | polar2grid.sh -r viirs_sdr -w geotiff -vv -p true_color false_color --grid-configs ${datapath}/grid_configs/grid_example.conf -g miami -f  | viirs/input/test1 | viirs/output/test1 |
 
+    Examples: MiRS
+      | command                                                                                           | source                      | output                       |
+      | polar2grid.sh -r mirs -w hdf5 -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f    | mirs/input/test2            | mirs/output/test2            |
+      | polar2grid.sh -r mirs -w binary -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f  | mirs/input/test2            | mirs/output/test3            |
+      | polar2grid.sh -r mirs -w geotiff -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f | mirs/input/test2            | mirs/output/test4            |
+      | polar2grid.sh -r mirs -w awips_tiled --grid-coverage 0 -g lcc_conus_1km --sector-id LCC --letters --compress -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f | mirs/input/test2            | mirs/output/test5            |
+
   Scenario Outline: Test list products output
     Given input data from <source>
     When <command> runs with --list-products

--- a/integration_tests/features/polar2grid.feature
+++ b/integration_tests/features/polar2grid.feature
@@ -39,7 +39,7 @@ Feature: Test polar2grid output images
       | command                                                                                           | source                      | output                       |
       | polar2grid.sh -r mirs -w hdf5 -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f    | mirs/input/test2            | mirs/output/test2            |
       | polar2grid.sh -r mirs -w binary -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f  | mirs/input/test2            | mirs/output/test3            |
-      | polar2grid.sh -r mirs -w geotiff -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f | mirs/input/test2            | mirs/output/test4            |
+      | polar2grid.sh -r mirs -w geotiff --fill-value 0 -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f | mirs/input/test2            | mirs/output/test4            |
       | polar2grid.sh -r mirs -w awips_tiled --grid-coverage 0 -g lcc_conus_1km --sector-id LCC --letters --compress -p tpw swe btemp_183h1 btemp_57h1 sea_ice rain_rate btemp_88v -f | mirs/input/test2            | mirs/output/test5            |
 
   Scenario Outline: Test list products output

--- a/integration_tests/features/steps/compare_images.py
+++ b/integration_tests/features/steps/compare_images.py
@@ -50,30 +50,16 @@ def step_impl(context, output):
     try:
         os.chdir(context.datapath)
         # NOTE: 81231 / 151404144 (0.054%) pixels are currently wrong in VIIRS_L1B.
-        if "geotiff" in context.command or context.script == "geo2grid.sh":
-            compare_command = " ".join(
-                [
-                    os.path.join(context.p2g_path, "p2g_compare_geotiff.sh"),
-                    output,
-                    context.temp_dir,
-                    "-vv",
-                    "--margin-of-error",
-                    str(81231 / 1514041.44),
-                ]
-            )
-        else:
-            compare_command = " ".join(
-                [
-                    os.path.join(context.p2g_path, "p2g_compare_netcdf.sh"),
-                    output,
-                    context.temp_dir,
-                    "-vv",
-                    "--margin-of-error",
-                    str(81231 / 1514041.44),
-                    "--variables",
-                    "data",
-                ]
-            )
+        compare_command = " ".join(
+            [
+                os.path.join(context.p2g_path, "p2g_compare.sh"),
+                output,
+                context.temp_dir,
+                "-vv",
+                "--margin-of-error",
+                str(81231 / 1514041.44),
+            ]
+        )
         exit_status = subprocess.call(compare_command, shell=True)
         assert exit_status == 0, "Files did not match with the correct output"
     finally:

--- a/swbundle/p2g_compare.sh
+++ b/swbundle/p2g_compare.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+### Verify simple test products with known products ###
+#
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+
+# Checks arguments
+if [ $# -lt 2 ] || [[ $* =~ (^|[[:space:]])("-h"|"--help")($|[[:space:]]) ]]; then
+    echo "Usage: p2g_compare.sh verification_dir work_dir"
+    # Prints only the optional arguments
+    print=0
+    options=`python -m polar2grid.compare -h`
+    while IFS= read line
+    do
+        if [[ "$line" =~ "optional" ]]; then
+            print=1
+        fi
+        if [[ $print -eq 1 ]]; then
+            echo "$line"
+        fi
+    done <<< "$options"
+    if [[ $* =~ (^|[[:space:]])("-h"|"--help")($|[[:space:]]) ]]; then
+        exit 0
+    fi
+    exit 1
+fi
+
+# Get primary and secondary directory names
+VERIFY_BASE=$1
+WORK_DIR=$2
+oops() {
+    echo "ERROR: $*"
+    echo "FAILURE"
+    exit 1
+}
+
+if [ ! -d $VERIFY_BASE ]; then
+    oops "Verification directory $VERIFY_BASE does not exist"
+fi
+
+if [ ! -d $WORK_DIR ]; then
+    oops "Working directory $WORK_DIR does not exist"
+fi
+
+# Run tests for each test data directory in the base directory
+BAD_COUNT=0
+for VFILE in $VERIFY_BASE/*; do
+    WFILE=$WORK_DIR/`basename $VFILE`
+    echo "INFO: Comparing $WFILE to known valid file $VFILE"
+    python -m polar2grid.compare "$VFILE" "$WFILE" `echo "${@:3}"`
+    [ $? -eq 0 ] || BAD_COUNT=$(($BAD_COUNT + 1))
+done
+
+if [ $BAD_COUNT -ne 0 ]; then
+    oops "$BAD_COUNT files were found to be unequal"
+fi
+
+# End of all tests
+echo "All files passed"
+echo "SUCCESS"


### PR DESCRIPTION
This adds a new set of tests for the MiRS reader with all of the common writers (binary, gtiff, hdf5, awips tiled). The original files were just added to the test directories on bumi by @kathys and by looking at the logs I've converted those commands to Polar2Grid 3.0 commands (the only change is the addition of the `--fill-value 0` on the geotiff line).