### PR TITLE
Change binary writer to default 64-bit floats to 32-bit floats

### DIFF
--- a/doc/source/readers/viirs_sdr.rst
+++ b/doc/source/readers/viirs_sdr.rst
@@ -1,35 +1,29 @@
 VIIRS SDR Reader
 ================
 
-.. automodule:: polar2grid.viirs.swath
+.. automodule:: polar2grid.readers.viirs_sdr
 
 Command Line Arguments
 ----------------------
 
 .. argparse::
-    :module: polar2grid.viirs.swath
-    :func: add_frontend_argument_groups
-    :prog: polar2grid.sh viirs_sdr <writer>
+    :module: polar2grid.readers.viirs_sdr
+    :func: add_reader_argument_groups
+    :prog: polar2grid.sh -r viirs_sdr -w <writer>
     :passparser:
-
-.. versionchanged:: 2.1
-    The reader name has been changed to ``viirs_sdr`` although ``viirs`` is still
-    supported for the time being.
 
 Examples:
 
 .. code-block:: bash
 
-    polar2grid.sh viirs_sdr gtiff -f <path to files>/<list of files>
+    polar2grid.sh -r viirs_sdr -w geotiff -f <path to files>/<list of files>
 
-    viirs2awips.sh -g 211e 211w -f ../sdr/*.h5
+    polar2grid.sh -r viirs_sdr -w geotiff -h
 
-    polar2grid.sh viirs_sdr gtiff -h
+    polar2grid.sh -r viirs_sdr -w geotiff --list-products -f ../sdr/*.h5
 
-    polar2grid.sh viirs_sdr gtiff --list-products -f ../sdr/*.h5
+    polar2grid.sh -r viirs_sdr -w awips_tiled -p i04 adaptive_dnb dynamic_dnb --sza-threshold=90.0 --letters --compress --sector-id Polar -g polar_alaska_1km -f <path to files>
 
-    polar2grid.sh viirs_sdr scmi -p i04 adaptive_dnb dynamic_dnb --sza-threshold=90.0 --letters --compress --sector-id Polar -g polar_alaska_1km -f <path to files>
+    polar2grid.sh -r viirs_sdr -w hdf5 --compress gzip --m-bands -f ../sdr/*.h5
 
-    polar2grid.sh viirs_sdr hdf5 --compress gzip --m-bands -f ../sdr/*.h5
-
-    polar2grid.sh viirs_sdr binary -g lcc_fit -p m15 -f ../sdr/SVM15*.h5 ../sdr/GMTCO*.h5
+    polar2grid.sh -r viirs_sdr -w binary -g lcc_fit -p m15 -f ../sdr/SVM15*.h5 ../sdr/GMTCO*.h5

--- a/etc/enhancements/abi.yaml
+++ b/etc/enhancements/abi.yaml
@@ -11,7 +11,7 @@ enhancements:
         kwargs:
          xp: [0., 25., 55., 100., 255.]
          fp: [0., 90., 140., 175., 255.]
-         coordinate_divisor: 255
+         reference_divisor: 255
   channel_8_default:
     name: C08
     operations:

--- a/etc/enhancements/abi.yaml
+++ b/etc/enhancements/abi.yaml
@@ -3,18 +3,15 @@ enhancements:
     sensor: abi
     standard_name: true_color
     operations:
-    - name: crefl_scaling
-      method: !!python/name:satpy.enhancements.crefl_scaling
-      kwargs:
-#       Polar2Grid's scaling: "Preferred".
-       idx: [0., 25., 55., 100., 255.]
-       sc: [0., 90., 140., 175., 255.]
-#       Ralph Kuehn's new scaling: Looks darker.
-#       idx: [0., 30., 60., 120., 190., 255.]
-#       sc: [0., 100., 128., 188., 223., 255.]
-#       Ralph Kuehn's old scaling: Looks brighter.
-#       idx: [0., 30., 60., 120., 190., 255.]
-#       sc: [0, 110, 160, 210, 240, 255]
+      - name: reflectance_range
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0., max_stretch: 100.}
+      - name: Linear interpolation
+        method: !!python/name:satpy.enhancements.piecewise_linear_stretch
+        kwargs:
+         xp: [0., 25., 55., 100., 255.]
+         fp: [0., 90., 140., 175., 255.]
+         coordinate_divisor: 255
   channel_8_default:
     name: C08
     operations:

--- a/etc/enhancements/abi.yaml
+++ b/etc/enhancements/abi.yaml
@@ -11,7 +11,7 @@ enhancements:
         kwargs:
          xp: [0., 25., 55., 100., 255.]
          fp: [0., 90., 140., 175., 255.]
-         reference_divisor: 255
+         reference_scale_factor: 255
   channel_8_default:
     name: C08
     operations:

--- a/etc/enhancements/ahi.yaml
+++ b/etc/enhancements/ahi.yaml
@@ -3,18 +3,15 @@ enhancements:
     sensor: ahi
     standard_name: true_color
     operations:
-      - name: crefl_scaling
-        method: !!python/name:satpy.enhancements.crefl_scaling
+      - name: reflectance_range
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0., max_stretch: 100.}
+      - name: Linear interpolation
+        method: !!python/name:satpy.enhancements.piecewise_linear_stretch
         kwargs:
-          #       Polar2Grid's scaling: "Preferred".
-          idx: [0., 25., 55., 100., 255.]
-          sc: [0., 90., 140., 175., 255.]
-  #       Ralph Kuehn's new scaling: Looks darker.
-  #       idx: [0., 30., 60., 120., 190., 255.]
-  #       sc: [0., 100., 128., 188., 223., 255.]
-  #       Ralph Kuehn's old scaling: Looks brighter.
-  #       idx: [0., 30., 60., 120., 190., 255.]
-  #       sc: [0, 110, 160, 210, 240, 255]
+          xp: [0., 25., 55., 100., 255.]
+          fp: [0., 90., 140., 175., 255.]
+          coordinate_divisor: 255
   channel_8_default:
     name: B08
     operations:

--- a/etc/enhancements/ahi.yaml
+++ b/etc/enhancements/ahi.yaml
@@ -11,7 +11,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          reference_divisor: 255
+          reference_scale_factor: 255
   channel_8_default:
     name: B08
     operations:

--- a/etc/enhancements/ahi.yaml
+++ b/etc/enhancements/ahi.yaml
@@ -11,7 +11,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          coordinate_divisor: 255
+          reference_divisor: 255
   channel_8_default:
     name: B08
     operations:

--- a/etc/enhancements/generic.yaml
+++ b/etc/enhancements/generic.yaml
@@ -48,3 +48,272 @@ enhancements:
         kwargs:
           min_stretch: -10.0
           max_stretch: 10.0
+
+  # Polar2Grid - MiRS Products
+  # MIRS BTs - ATMS
+  btemp_23v:
+    name: btemp_23v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 140, max_stretch: 300.}
+  btemp_31v:
+    name: btemp_31v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 140, max_stretch: 300.}
+  btemp_50h:
+    name: btemp_50h
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 170, max_stretch: 290.}
+  btemp_51h:
+    name: btemp_51h
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 170, max_stretch: 290.}
+  btemp_52h:
+    name: btemp_52h
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 170, max_stretch: 290.}
+  btemp_53h:
+    name: btemp_53h
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 270.}
+  btemp_54h1:
+    name: btemp_54h1
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 250.}
+  btemp_54h2:
+    name: btemp_54h2
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 210, max_stretch: 230.}
+  btemp_55h:
+    name: btemp_55h
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 230.}
+  btemp_57h1:
+    name: btemp_57h1
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 230.}
+  btemp_57h2:
+    name: btemp_57h2
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180, max_stretch: 230.}
+  btemp_57h3:
+    name: btemp_57h3
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180, max_stretch: 250.}
+  btemp_57h4:
+    name: btemp_57h4
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180, max_stretch: 250.}
+  btemp_57h5:
+    name: btemp_57h5
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180, max_stretch: 280.}
+  btemp_57h6:
+    name: btemp_57h6
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 290.}
+  btemp_88v:
+    name: btemp_88v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 150, max_stretch: 300.}
+  btemp_165h:
+    name: btemp_165h
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 150, max_stretch: 300.}
+  btemp_183h1_npp:
+    name: btemp_183h1
+    platform_name: npp
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 220, max_stretch: 300.}
+  btemp_183h2_npp:
+    name: btemp_183h2
+    platform_name: npp
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 220, max_stretch: 300.}
+  btemp_183h3:
+    name: btemp_183h3
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 220, max_stretch: 280.}
+  btemp_183h4:
+    name: btemp_183h4
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 300.}
+  btemp_183h5:
+    name: btemp_183h5
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 220, max_stretch: 265.}
+
+  # MIRS BTs - NOAA-18 - AMSU-A MHS
+  # MIRS BTs - NOAA-19 - AMSU-A MHS
+  # MIRS BTs - M1 (metopb) - AMSU-A MHS
+  # MIRS BTs - M2 (metopa) - AMSU-A MHS
+  btemp_50v:
+    name: btemp_50v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 170, max_stretch: 290.}
+  btemp_52v:
+    name: btemp_52v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 170, max_stretch: 290.}
+  btemp_54h:
+    name: btemp_54h
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 250.}
+  btemp_54v:
+    name: btemp_54v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 210, max_stretch: 230.}
+  btemp_89v1:
+    name: btemp_89v1
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 150, max_stretch: 300.}
+  btemp_89v2:
+    name: btemp_89v2
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 150, max_stretch: 300.}
+  # 157h on OPSO NOAA site
+  btemp_157v:
+    name: btemp_157v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 150, max_stretch: 300.}
+  # 184h on OSPO NOAA site
+  # http://www.ospo.noaa.gov/Products/atmosphere/mirs/prod_mon.html?sat=JPSS
+  btemp_183h1:
+    name: btemp_183h1
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 220, max_stretch: 265.}
+  # 186h on OSPO NOAA site
+  btemp_183h2:
+    name: btemp_183h2
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 220, max_stretch: 280.}
+  btemp_190v:
+    name: btemp_190v
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 200, max_stretch: 300.}
+
+  # Polar2Grid - CLAVR-x products
+  clavrx_cloud_type:
+    name: cloud_type
+    operations: {}
+  clavrx_cld_temp_acha:
+    name: cld_temp_acha
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 160, max_stretch: 320.}
+  clavrx_cld_height_acha:
+    name: cld_height_acha
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 20000.}
+  clavrx_cloud_phase:
+    name: cloud_phase
+    operations: {}
+  clavrx_cld_opd_dcomp:
+    name: cld_opd_dcomp
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: -0.2, max_stretch: 160.}
+  clavrx_cld_opd_nlcomp:
+    name: cld_opd_nlcomp
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: -0.2, max_stretch: 160.}
+  clavrx_cld_reff_dcomp:
+    name: cld_reff_dcomp
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 160.}
+  clavrx_cld_reff_nlcomp:
+    name: cld_reff_nlcomp
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 160.}
+  clavrx_cld_emiss_acha:
+    name: cld_emiss_acha
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 1.}
+  clavrx_refl_lunar_dnb_nom:
+    name: refl_lunar_dnb_nom
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: -2.0, max_stretch: 150.}
+  # NOTE: rain_rate is slightly different in CLAVR-X versus MiRS
+  clavrx_rain_rate:
+    name: rain_rate
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 32.}

--- a/etc/enhancements/generic.yaml
+++ b/etc/enhancements/generic.yaml
@@ -19,7 +19,8 @@ enhancements:
         min_in: -110.15
         max_in: 56.85
   radiance_default:
-    calibration: radiance
+    # radiance
+    standard_name: toa_outgoing_radiance_per_unit_wavelength
     operations:
       - name: stretch
         method: !!python/name:satpy.enhancements.stretch

--- a/etc/enhancements/viirs.yaml
+++ b/etc/enhancements/viirs.yaml
@@ -3,30 +3,77 @@ enhancements:
     sensor: viirs
     standard_name: true_color
     operations:
-      - name: crefl_scaling
-        method: !!python/name:satpy.enhancements.crefl_scaling
+      - name: reflectance_range
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: -1., max_stretch: 110.}
+      - name: Linear interpolation
+        method: !!python/name:satpy.enhancements.piecewise_linear_stretch
         kwargs:
-          idx: [0., 25., 55., 100., 255.]
-          sc: [0., 90., 140., 175., 255.]
+          xp: [0., 25., 55., 100., 255.]
+          fp: [0., 90., 140., 175., 255.]
+          coordinate_divisor: 255
   false_color_crefl:
     sensor: viirs
     standard_name: false_color
     operations:
-      - name: crefl_scaling
-        method: !!python/name:satpy.enhancements.crefl_scaling
+      - name: reflectance_range
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: -1., max_stretch: 110.}
+      - name: Linear interpolation
+        method: !!python/name:satpy.enhancements.piecewise_linear_stretch
         kwargs:
-          idx: [0., 25., 55., 100., 255.]
-          sc: [0., 90., 140., 175., 255.]
+          xp: [0., 25., 55., 100., 255.]
+          fp: [0., 90., 140., 175., 255.]
+          coordinate_divisor: 255
   viirs_crefl:
     sensor: viirs
     standard_name: corrected_reflectance
     operations:
-      - name: crefl_scaling
-        method: !!python/name:satpy.enhancements.crefl_scaling
+      - name: reflectance_range
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: -1., max_stretch: 110.}
+      - name: Linear interpolation
+        method: !!python/name:satpy.enhancements.piecewise_linear_stretch
         kwargs:
-          idx: [0., 25., 55., 100., 255.]
-          sc: [0., 90., 140., 175., 255.]
+          xp: [0., 25., 55., 100., 255.]
+          fp: [0., 90., 140., 175., 255.]
+          coordinate_divisor: 255
   pre_enhanced_viirs_crefl:
     sensor: viirs
     standard_name: preenhanced_crefl
     operations: []
+
+  # Polar2Grid - VIIRS EDR Active Fires
+  viirs_confidence_cat:
+    name: confidence_cat
+    sensor: viirs
+    operations:
+      - name: colorize
+        method: !!python/name:satpy.enhancements.colorize
+        kwargs:
+          palettes:
+            - {colors: ylorrd, min_value: 7, max_value: 9}
+  viirs_confidence_pct:
+    name: confidence_pct
+    sensor: viirs
+    operations:
+      - name: colorize
+        method: !!python/name:satpy.enhancements.colorize
+        kwargs:
+          palettes:
+            - {colors: ylorrd, min_value: 0, max_value: 100}
+  viirs_fire_power:
+    name: power
+    sensor: viirs
+    operations:
+      - name: colorize
+        method: !!python/name:satpy.enhancements.colorize
+        kwargs:
+          palettes:
+            - {colors: ylorrd, min_value: 0, max_value: 250}
+
+  # VIIRS EDR Flood - Configured in Satpy
+#  viirs_water_detection:
+#    name: WaterDetection
+#    sensor: viirs
+#    operations: {}

--- a/etc/enhancements/viirs.yaml
+++ b/etc/enhancements/viirs.yaml
@@ -11,7 +11,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          coordinate_divisor: 255
+          reference_divisor: 255
   false_color_crefl:
     sensor: viirs
     standard_name: false_color
@@ -24,7 +24,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          coordinate_divisor: 255
+          reference_divisor: 255
   viirs_crefl:
     sensor: viirs
     standard_name: corrected_reflectance
@@ -37,7 +37,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          coordinate_divisor: 255
+          reference_divisor: 255
   pre_enhanced_viirs_crefl:
     sensor: viirs
     standard_name: preenhanced_crefl

--- a/etc/enhancements/viirs.yaml
+++ b/etc/enhancements/viirs.yaml
@@ -11,7 +11,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          reference_divisor: 255
+          reference_scale_factor: 255
   false_color_crefl:
     sensor: viirs
     standard_name: false_color
@@ -24,7 +24,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          reference_divisor: 255
+          reference_scale_factor: 255
   viirs_crefl:
     sensor: viirs
     standard_name: corrected_reflectance
@@ -37,7 +37,7 @@ enhancements:
         kwargs:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
-          reference_divisor: 255
+          reference_scale_factor: 255
   pre_enhanced_viirs_crefl:
     sensor: viirs
     standard_name: preenhanced_crefl

--- a/polar2grid/compare.py
+++ b/polar2grid/compare.py
@@ -44,12 +44,12 @@ from os.path import exists
 import sys
 
 import logging
-import numpy
+import numpy as np
 
 LOG = logging.getLogger(__name__)
 
 
-def compare_array(array1, array2, atol=0.0, rtol=0.0, margin_of_error=0.0):
+def isclose_array(array1, array2, atol=0.0, rtol=0.0, margin_of_error=0.0, **kwargs):
     """Compare 2 binary arrays per pixel
 
     Two pixels are considered different if the absolute value of their
@@ -70,7 +70,7 @@ def compare_array(array1, array2, atol=0.0, rtol=0.0, margin_of_error=0.0):
         raise ValueError("Data shapes were not equal: {} | {}".format(array1.shape, array2.shape))
 
     total_pixels = array1.size
-    equal_pixels = numpy.count_nonzero(numpy.isclose(array1, array2, rtol=rtol, atol=atol, equal_nan=True))
+    equal_pixels = np.count_nonzero(np.isclose(array1, array2, rtol=rtol, atol=atol, equal_nan=True))
     diff_pixels = total_pixels - equal_pixels
     if diff_pixels > margin_of_error / 100 * total_pixels:
         LOG.warning("%d pixels out of %d pixels are different" % (diff_pixels, total_pixels))
@@ -79,11 +79,38 @@ def compare_array(array1, array2, atol=0.0, rtol=0.0, margin_of_error=0.0):
     return 0
 
 
-def compare_binary(fn1, fn2, shape, dtype, atol=0.0, margin_of_error=0.0, **kwargs):
-    array1 = numpy.memmap(fn1, shape=shape, dtype=dtype, mode="r")
-    array2 = numpy.memmap(fn2, shape=shape, dtype=dtype, mode="r")
+def plot_array(array1, array2, cmap="viridis", vmin=None, vmax=None, **kwargs):
+    """Debug two arrays being different by visually comparing them."""
+    import matplotlib.pyplot as plt
 
-    return compare_array(array1, array2, atol=atol, margin_of_error=margin_of_error)
+    LOG.info("Plotting arrays...")
+    if vmin is None:
+        vmin = min(np.nanmin(array1), np.nanmin(array2))
+        vmax = max(np.nanmax(array1), np.nanmax(array2))
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    ax1.imshow(array1, cmap=cmap, vmin=vmin, vmax=vmax)
+    ax2.imshow(array2, cmap=cmap, vmin=vmin, vmax=vmax)
+    plt.show()
+    return 0
+
+
+def compare_array(array1, array2, plot=False, **kwargs):
+    if plot:
+        return plot_array(array1, array2, **kwargs)
+    else:
+        return isclose_array(array1, array2, **kwargs)
+
+
+def compare_binary(fn1, fn2, shape, dtype, atol=0.0, margin_of_error=0.0, **kwargs):
+    if dtype is None:
+        dtype = np.float32
+    mmap_kwargs = {"dtype": dtype, "mode": "r"}
+    if shape is not None and shape[0] is not None:
+        mmap_kwargs["shape"] = shape
+    array1 = np.memmap(fn1, **mmap_kwargs)
+    array2 = np.memmap(fn2, **mmap_kwargs)
+
+    return compare_array(array1, array2, atol=atol, margin_of_error=margin_of_error, **kwargs)
 
 
 def compare_geotiff(gtiff_fn1, gtiff_fn2, atol=0.0, margin_of_error=0.0, **kwargs):
@@ -100,10 +127,10 @@ def compare_geotiff(gtiff_fn1, gtiff_fn2, atol=0.0, margin_of_error=0.0, **kwarg
     gtiff1 = gdal.Open(gtiff_fn1, gdal.GA_ReadOnly)
     gtiff2 = gdal.Open(gtiff_fn2, gdal.GA_ReadOnly)
 
-    array1 = gtiff1.GetRasterBand(1).ReadAsArray().astype(numpy.float32)
-    array2 = gtiff2.GetRasterBand(1).ReadAsArray().astype(numpy.float32)
+    array1 = gtiff1.GetRasterBand(1).ReadAsArray().astype(np.float32)
+    array2 = gtiff2.GetRasterBand(1).ReadAsArray().astype(np.float32)
 
-    return compare_array(array1, array2, atol=atol, margin_of_error=margin_of_error)
+    return compare_array(array1, array2, atol=atol, margin_of_error=margin_of_error, **kwargs)
 
 
 def compare_awips_netcdf(nc1_name, nc2_name, atol=0.0, margin_of_error=0.0, **kwargs):
@@ -123,10 +150,10 @@ def compare_awips_netcdf(nc1_name, nc2_name, atol=0.0, margin_of_error=0.0, **kw
     image2_var = nc2.variables["image"]
     image1_var.set_auto_maskandscale(False)
     image2_var.set_auto_maskandscale(False)
-    image1_data = image1_var[:].astype(numpy.uint8).astype(numpy.float32)
-    image2_data = image2_var[:].astype(numpy.uint8).astype(numpy.float32)
+    image1_data = image1_var[:].astype(np.uint8).astype(np.float32)
+    image2_data = image2_var[:].astype(np.uint8).astype(np.float32)
 
-    return compare_array(image1_data, image2_data, atol=atol, margin_of_error=margin_of_error)
+    return compare_array(image1_data, image2_data, atol=atol, margin_of_error=margin_of_error, **kwargs)
 
 
 def compare_netcdf(nc1_name, nc2_name, variables, atol=0.0, margin_of_error=0.0, **kwargs):
@@ -141,7 +168,7 @@ def compare_netcdf(nc1_name, nc2_name, variables, atol=0.0, margin_of_error=0.0,
         image1_var.set_auto_maskandscale(False)
         image2_var.set_auto_maskandscale(False)
         LOG.debug("Comparing data for variable '{}'".format(v))
-        num_diff += compare_array(image1_var, image2_var, atol=atol, margin_of_error=margin_of_error)
+        num_diff += compare_array(image1_var, image2_var, atol=atol, margin_of_error=margin_of_error, **kwargs)
     return num_diff
 
 
@@ -155,7 +182,7 @@ def compare_hdf5(nc1_name, nc2_name, variables, atol=0.0, margin_of_error=0.0, *
         image1_var = nc1[v]
         image2_var = nc2[v]
         LOG.debug("Comparing data for variable '{}'".format(v))
-        num_diff += compare_array(image1_var, image2_var, atol=atol, margin_of_error=margin_of_error)
+        num_diff += compare_array(image1_var, image2_var, atol=atol, margin_of_error=margin_of_error, **kwargs)
     return num_diff
 
 
@@ -222,6 +249,11 @@ def main(argv=sys.argv[1:]):
     )
     parser.add_argument("--dtype", type=str_to_dtype, help="Data type for binary file comparison only")
     parser.add_argument("--variables", nargs="+", help="NetCDF variables to read and compare")
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        help="Show a plot of the two arrays instead of " "checking equality. Used for debugging.",
+    )
     parser.add_argument("--margin-of-error", type=float, default=0.0, help="percent of total pixels that can be wrong")
     parser.add_argument(
         "file_type",
@@ -235,7 +267,7 @@ def main(argv=sys.argv[1:]):
 
     levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
     logging.basicConfig(level=levels[min(3, args.verbosity)])
-    kwargs = {"shape": tuple(args.shape), "dtype": args.dtype, "variables": args.variables}
+    kwargs = {"shape": tuple(args.shape), "dtype": args.dtype, "variables": args.variables, "plot": args.plot}
 
     if not exists(args.file1):
         LOG.error("Could not find file {}".format(args.file1))

--- a/polar2grid/tests/test_writers/test_binary.py
+++ b/polar2grid/tests/test_writers/test_binary.py
@@ -106,7 +106,7 @@ class TestBinaryWriter:
         exp_fn = tmpdir.join("noaa-20_viirs_fake_p2g_name_20210101_120000_fake_area.dat")
 
         if dst_dtype is None:
-            dst_dtype = src_dtype
+            dst_dtype = src_dtype if src_dtype != np.float64 else np.float32
         assert os.path.isfile(exp_fn)
         data = np.memmap(str(exp_fn), mode="r", dtype=dst_dtype)
         exp_data = self._generate_expected_output(src_data_arr, dst_dtype, enhance)

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -48,7 +48,11 @@ import dask.array as da
 logger = logging.getLogger(__name__)
 
 DEFAULT_OUTPUT_FILENAMES = {
-    None: "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat"
+    None: "{platform_name!u}_{sensor!u}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+    "abi_l1b": "{platform_name!u}_{sensor!u}_{observation_type}{scene_abbr}_"
+    "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+    "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+    "mirs": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
 }
 
 

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -23,9 +23,13 @@
 """The Binary writer writes band data to a flat binary file.
 
 By default it enhances the data based on the enhancement configuration file
-and then saves the data to a flat binary file of the same data type. A different
-output type can be specified as well as the ``--no-enhance`` command line flag to
-write the "raw" band data.
+and then saves the data to a flat binary file. The output data type will match
+the input data for integer types (ex. uint8 -> uint8), but floating point types
+will always be forced to 32-bit floats for consistency between readers and
+changes in the low-level Satpy library. A different output type can be
+specified using the ``--dtype`` flag. To turn off scaling of the data (a.k.a.
+enhancements) the ``--no-enhance`` command line flag can be specified to write
+the "raw" band data.
 
 """
 
@@ -64,8 +68,14 @@ class FlatBinaryWriter(ImageWriter):
         img = get_enhanced_image(
             dataset.squeeze(), enhance=self.enhancer, overlay=overlay, decorate=decorate, fill_value=fill_value
         )
-        kwargs["dtype"] = kwargs.get("dtype") or dataset.dtype
+        kwargs["dtype"] = kwargs.get("dtype") or self._get_default_dtype(dataset)
         return self.save_image(img, filename=filename, compute=compute, fill_value=fill_value, **kwargs)
+
+    @staticmethod
+    def _get_default_dtype(data_arr: xr.DataArray) -> np.dtype:
+        if data_arr.dtype == np.float64:
+            return np.float32
+        return data_arr.dtype
 
     def save_image(self, img, filename=None, compute=True, dtype=None, fill_value=None, **kwargs):
         filename = filename or self.get_filename(

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -49,7 +49,8 @@ DEFAULT_OUTPUT_FILENAMES = {
     None: "{platform_name!u}_{sensor!u}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
     "abi_l1b": "{platform_name!u}_{sensor!u}_{observation_type}{scene_abbr}_"
     "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_" "{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+    "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+    "mirs": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
 }
 
 


### PR DESCRIPTION
To avoid inconsistencies as Satpy changes, the binary writer needs to have consistent output for floating point data. With current versions of xarray (this may change in the future) it is very easy for Satpy to accidentally upcast 32-bit floats to 64-bit floats. This amount of precision is unnecessary for most remote-sensing satellite instruments and wastes space and processing time. This PR makes it so instead of defaulting to the same data type as the input data, the writer will cast 64-bit floats as 32-bit floats. This way if Satpy or xarray changes in the future produce the same data as 32-bit floats, this won't change output for P2G users.

This PR also includes fixing output filenames for the geotiff and binary writers, fixing the default radiance enhancement configuration, and adding a `--plot` option to the compare script for debugging.