### PR TITLE
Add ability to pass S3 URLs

### DIFF
--- a/build_environment.yml
+++ b/build_environment.yml
@@ -39,5 +39,7 @@ dependencies:
   - scipy
   - zarr
   - xarray
+  - fsspec
+  - s3fs
   - pip:
     - git+https://github.com/pytroll/satpy.git

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -44,4 +44,6 @@ dependencies:
   - satpy
   - python-graphviz
   - sphinx-argparse
+  - fsspec
+  - s3fs
   - sphinxcontrib-apidoc


### PR DESCRIPTION
This is an initial attempt to allow users to pass URLs to S3 files. It allows for `s3://` style URLs and assumes anonymous access is allowed. It also allows you to prefix with `simplecache::` (a feature of the `fsspec` python library) and it will cache the files locally and improves performance. Note that this caching will write to a temporary directory by default so it is up to the system/user to clear it out. There are many improvements and options that could be added.

To support this in Satpy with more flexibility a `FSFile` class was created to wrap `fsspec` open file objects. This PR takes advantage of this interface. There are others available to get S3 resources to xarray, but this is the only one that is currently available to Satpy.

FYI @rayg-ssec 