### PR TITLE
Fix various HDF5 writer issues

### DIFF
--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -25,6 +25,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from typing import Union, Iterable, Generator, Optional
 from satpy import Scene, DataID, DataQuery
@@ -46,9 +47,6 @@ def convert_old_p2g_date_frmts(frmt):
         new_start = "start_time{}".format(new_frmt)
         frmt = frmt.replace(old_start, new_start)
 
-        old_begin = "begin_time{}".format(old_frmt)
-        frmt = frmt.replace(old_begin, new_start)
-
         old_end = "end_time{}".format(old_frmt)
         new_end = "end_time{}".format(new_frmt)
         frmt = frmt.replace(old_end, new_end)
@@ -65,6 +63,13 @@ def convert_p2g_pattern_to_satpy(pattern):
         "begin_time": "start_time",
         "product_name": "p2g_name",
     }
+    # If there is no other formatting before replacing begin_time,
+    # add the old default formatting to the pattern and changed begin_time to
+    # start_time
+    abs_search = re.compile(r"{begin_time}").search
+    if bool(abs_search(pattern)):
+        pattern = pattern.replace("{begin_time}", "{start_time:%Y%m%d_%H%M}")
+
     for p2g_kw, satpy_kw in replacements.items():
         pattern = pattern.replace(p2g_kw, satpy_kw)
     pattern = convert_old_p2g_date_frmts(pattern)

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -25,7 +25,6 @@
 from __future__ import annotations
 
 import logging
-import re
 
 from typing import Union, Iterable, Generator, Optional
 from satpy import Scene, DataID, DataQuery
@@ -66,9 +65,7 @@ def convert_p2g_pattern_to_satpy(pattern):
     # If there is no other formatting before replacing begin_time,
     # add the old default formatting to the pattern and changed begin_time to
     # start_time
-    abs_search = re.compile(r"{begin_time}").search
-    if bool(abs_search(pattern)):
-        pattern = pattern.replace("{begin_time}", "{start_time:%Y%m%d_%H%M}")
+    pattern = pattern.replace("{begin_time}", "{start_time:%Y%m%d_%H%M}")
 
     for p2g_kw, satpy_kw in replacements.items():
         pattern = pattern.replace(p2g_kw, satpy_kw)

--- a/polar2grid/writers/hdf5.py
+++ b/polar2grid/writers/hdf5.py
@@ -165,10 +165,11 @@ class HDF5Writer(Writer):
                     pass
                 else:
                     group.attrs[a] = ds_attr
-            group.attrs["cell_height"] = np.format_float_positional(area_def.pixel_size_y, precision=4)
-            group.attrs["cell_width"] = np.format_float_positional(area_def.pixel_size_x, precision=4)
-            group.attrs["origin_x"] = area_def.area_extent[0]
-            group.attrs["origin_y"] = area_def.area_extent[1]
+
+            group.attrs["cell_height"] = np.round(-area_def.pixel_size_y, 5)
+            group.attrs["cell_width"] = np.round(area_def.pixel_size_x, 5)
+            group.attrs["origin_x"] = area_def.pixel_upper_left[0]
+            group.attrs["origin_y"] = area_def.pixel_upper_left[1]
 
         return projection_name
 
@@ -273,7 +274,7 @@ class HDF5Writer(Writer):
                 targets.append(fnames)
 
             for data_arr in data_arrs:
-                hdf_subgroup = "{}/{}".format(parent_group, data_arr.attrs["name"])
+                hdf_subgroup = "{}/{}".format(parent_group, data_arr.attrs["p2g_name"])
 
                 file_var = FakeHDF5(filename, hdf_subgroup)
                 self.create_variable(filename, HDF5_fh, hdf_subgroup, data_arr, dtype, compression)

--- a/polar2grid/writers/hdf5.py
+++ b/polar2grid/writers/hdf5.py
@@ -157,15 +157,18 @@ class HDF5Writer(Writer):
             group.attrs["height"], group.attrs["width"] = area_def.shape
             group.attrs["description"] = "No projection: native format"
         else:
-            for a in ["height", "width", "origin_x", "origin_y"]:
+
+            group.attrs["proj4_definition"] = area_def.proj4_string
+            for a in ["height", "width"]:
                 ds_attr = getattr(area_def, a, None)
                 if ds_attr is None:
                     pass
                 else:
                     group.attrs[a] = ds_attr
-            group.attrs["proj4_string"] = area_def.proj_str
-            group.attrs["cell_height"] = area_def.pixel_size_y
-            group.attrs["cell_width"] = area_def.pixel_size_x
+            group.attrs["cell_height"] = np.format_float_positional(area_def.pixel_size_y, precision=4)
+            group.attrs["cell_width"] = np.format_float_positional(area_def.pixel_size_x, precision=4)
+            group.attrs["origin_x"] = area_def.area_extent[0]
+            group.attrs["origin_y"] = area_def.area_extent[1]
 
         return projection_name
 
@@ -248,8 +251,7 @@ class HDF5Writer(Writer):
 
         filename = output_names[0]
         if not all_equal(output_names):
-            LOG.warning("More than one output filename possible. "
-                        "Writing to only '{}'.".format(filename))
+            LOG.warning("More than one output filename possible. " "Writing to only '{}'.".format(filename))
 
         HDF5_fh = self.open_HDF5_filehandle(filename, append=append)
 


### PR DESCRIPTION
HDF5 writer: Metadata Fixes: change grid projection string to the proj4_string, reverses cell height and adds x and y origin values.  Write the p2g_name to the files rather than the satpy name for the variables.  

Update the pattern conversion so that begin_time defaults to the format that was produced in the previous output_filename which is now start_time:%Y%m%d_%H%M.  start_time, when entered alone should still output the default date pattern which is in isoformat.  
