### PR TITLE
Add proxy module for Satpy clavrx reader

### DIFF
--- a/etc/enhancements/generic.yaml
+++ b/etc/enhancements/generic.yaml
@@ -311,7 +311,10 @@ enhancements:
   # Polar2Grid - CLAVR-x products
   clavrx_cloud_type:
     name: cloud_type
-    operations: {}
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 13.}
   clavrx_cld_temp_acha:
     name: cld_temp_acha
     operations:
@@ -326,7 +329,10 @@ enhancements:
         kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 20000.}
   clavrx_cloud_phase:
     name: cloud_phase
-    operations: {}
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 6.}
   clavrx_cld_opd_dcomp:
     name: cld_opd_dcomp
     operations:

--- a/etc/enhancements/generic.yaml
+++ b/etc/enhancements/generic.yaml
@@ -311,10 +311,7 @@ enhancements:
   # Polar2Grid - CLAVR-x products
   clavrx_cloud_type:
     name: cloud_type
-    operations:
-      - name: linear_stretch
-        method: !!python/name:satpy.enhancements.stretch
-        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 13.}
+    operations: {}
   clavrx_cld_temp_acha:
     name: cld_temp_acha
     operations:
@@ -329,10 +326,7 @@ enhancements:
         kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 20000.}
   clavrx_cloud_phase:
     name: cloud_phase
-    operations:
-      - name: linear_stretch
-        method: !!python/name:satpy.enhancements.stretch
-        kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 6.}
+    operations: {}
   clavrx_cld_opd_dcomp:
     name: cld_opd_dcomp
     operations:

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -100,11 +100,6 @@ else:
         ]
     )
 
-DAY_ONLY = ["cld_opd_dcomp", "cld_reff_dcomp"]
-NIGHT_ONLY = ["cld_opd_nlcomp", "cld_reff_nlcomp", "refl_lunar_dnb_nom"]
-
-FILE_EXTENSIONS = [".hdf"]
-DEFAULT_READER_NAME = "clavrx"
 DEFAULT_DATASETS = [
     "cloud_type" "cld_temp_acha",
     "cld_height_acha",
@@ -146,16 +141,6 @@ class ReaderProxy(ReaderProxyBase):
     def get_default_products(self) -> list[str]:
         """Get products to load if users hasn't specified any others."""
         return set(DEFAULT_DATASETS) & self.get_all_products()
-
-    def filter(self, scn):
-        self.filter_daynight_datasets(scn)
-
-    def filter_daynight_datasets(self, scene):
-        """Some products are only available at daytime or nighttime"""
-        for k in DAY_ONLY + NIGHT_ONLY:
-            if k in scene and scene[k].isnull().all():
-                LOG.info("Removing dataset '{}' because it is completely empty".format(k))
-                del scene[k]
 
 
 def add_reader_argument_groups(

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -118,6 +118,17 @@ DEFAULT_DATASETS = [
     "rain_rate",
 ]
 
+FILTERS = {
+    "day_only": {
+        "standard_name": [
+            "toa_bidirectional_reflectance",
+            "effective_radius_of_cloud_condensed_water_particles_at_cloud_top",
+            "atmosphere_optical_thickness_due_to_cloud",
+        ]
+    },
+    "night_only": {"standard_name": ["refl_lunar_dnb_nom"]},
+}
+
 
 class ReaderProxy(ReaderProxyBase):
     """Provide Polar2Grid-specific information about this reader's products."""

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -65,16 +65,11 @@ support for the VIIRS Day/Night Band Lunar Reflectance:
 
 """
 from __future__ import annotations
+from typing import Optional
 
-from argparse import ArgumentParser, _ArgumentGroup
 import os
-import sys
-import logging
-import numpy as np
+from argparse import ArgumentParser, _ArgumentGroup
 from ._base import ReaderProxyBase
-from polar2grid.readers import ReaderWrapper, main
-
-LOG = logging.getLogger(__name__)
 
 # Limit the number of products shown to Polar2Grid users
 # if the user uses the environment variable they can display more
@@ -134,11 +129,11 @@ class ReaderProxy(ReaderProxyBase):
 
     def get_all_products(self) -> list[str]:
         """Get all polar2grid products that could be loaded."""
-        return set(ADVERTISED_DATASETS) & set(self.scn.all_dataset_names())
+        return ADVERTISED_DATASETS
 
     def get_default_products(self) -> list[str]:
         """Get products to load if users hasn't specified any others."""
-        return set(DEFAULT_DATASETS) & self.get_all_products()
+        return DEFAULT_DATASETS
 
 
 def add_reader_argument_groups(

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -132,9 +132,6 @@ class ReaderProxy(ReaderProxyBase):
     is_geo2grid_reader = True
     is_polar2grid_reader = True
 
-    def available_product_names(self) -> set(str):
-        return sorted(set(self.scn.available_dataset_names()))
-
     def get_all_products(self) -> list[str]:
         """Get all polar2grid products that could be loaded."""
         return set(ADVERTISED_DATASETS) & set(self.scn.all_dataset_names())

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -101,7 +101,8 @@ else:
     )
 
 DEFAULT_DATASETS = [
-    "cloud_type" "cld_temp_acha",
+    "cloud_type",
+    "cld_temp_acha",
     "cld_height_acha",
     "cloud_phase",
     "cld_opd_dcomp",
@@ -131,7 +132,7 @@ class ReaderProxy(ReaderProxyBase):
     is_geo2grid_reader = True
     is_polar2grid_reader = True
 
-    def available_product_names(self) -> sorted(set(str)):
+    def available_product_names(self) -> set(str):
         return sorted(set(self.scn.available_dataset_names()))
 
     def get_all_products(self) -> list[str]:

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -128,13 +128,13 @@ class ReaderProxy(ReaderProxyBase):
     def available_product_names(self) -> sorted(set(str)):
         return sorted(set(self.scn.available_dataset_names()))
 
-    def available_product_names(self) -> list[str]:
+    def get_all_products(self) -> list[str]:
         """Get all polar2grid products that could be loaded."""
         return set(ADVERTISED_DATASETS) & set(self.scn.all_dataset_names())
 
     def get_default_products(self) -> list[str]:
         """Get products to load if users hasn't specified any others."""
-        return set(DEFAULT_DATASETS) & self.available_product_names()
+        return set(DEFAULT_DATASETS) & self.get_all_products()
 
     def filter(self, scn):
         self.filter_daynight_datasets(scn)

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -53,6 +53,7 @@ DEFAULT_OUTPUT_FILENAMES = {
     "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
     "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
     "mirs": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+    "clavrx": "{platform_name!l}_{sensor!l}_{name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
 }
 
 

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -51,6 +51,7 @@ DEFAULT_OUTPUT_FILENAMES = {
     "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
     "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
     "mirs": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+    "clavrx": "{platform_name!l}_{sensor!l}_{name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
 }
 
 


### PR DESCRIPTION
Update the Clavr-x wrapper referenced in #318.  A dictionary has been added with day/night products for filter following the viirs_sdr wrapper.  This means that the day/night product filter uses standard names rather than variable names.  Changes to wrapper are based on the example set in the viirs_sdr reader.  The Frontend class and group arguments have been removed.  The DAY_ONLY and NIGHT_ONLY variable names are still in the wrapper, but as far as I can tell, they are not used?  I am concerned that the standard_name for the  toa_bidirectional_reflectance is too general because channel 7 is a mixed solar and thermal and produces a product in both day and night hours.  