### PR TITLE
Fix description of ABI L1b Night Microphysics RGB

### DIFF
--- a/doc/source/readers/abi_l1b.rst
+++ b/doc/source/readers/abi_l1b.rst
@@ -66,9 +66,10 @@ Examples:
     Night Microphysics
     ^^^^^^^^^^^^^^^^^^
 
-    The Cooperative Institute for Research in the Atmosphere (CIRA) has put
-    together a complete guide on the Night Microphysics RGB image. You can
-    access the PDF
+    The Cooperative Institute for Research in the Atmosphere (CIRA) hosts
+    various Quick Guides for common GOES-R ABI RGB recipes. Kevin Fuell of
+    NASA SPoRT has put together a guide on the Night Microphysics RGB image.
+    You can access the PDF
     `here <http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_NtMicroRGB_Final_20191206.pdf>`_.
 
     C01 through C06


### PR DESCRIPTION
Scott Bachmeier pointed out that we were crediting CIRA with the creation of the night microphysics guide, but it was actually contributed by Kevin Fuell at NASA SPoRT.