### PR TITLE
Update writer default filenames to be based on Polar2Grid or Geo2Grid

### DIFF
--- a/polar2grid/writers/awips_tiled.py
+++ b/polar2grid/writers/awips_tiled.py
@@ -84,9 +84,16 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_OUTPUT_PATTERN = "{source_name}_AII_{platform_name}_{sensor}_{p2g_name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc"
+DEFAULT_OUTPUT_PATTERN = (
+    "{source_name}_AII_{platform_name}_{sensor}_{p2g_name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc"
+)
 DEFAULT_OUTPUT_FILENAMES = {
-    None: DEFAULT_OUTPUT_PATTERN,
+    "polar2grid": {
+        None: DEFAULT_OUTPUT_PATTERN,
+    },
+    "geo2grid": {
+        None: DEFAULT_OUTPUT_PATTERN,
+    },
 }
 
 
@@ -97,9 +104,7 @@ def add_writer_argument_groups(parser, group=None):
         group = parser.add_argument_group(title="AWIPS Tiled Writer")
     # group_1.add_argument('--file-pattern', default=DEFAULT_OUTPUT_PATTERN,
     #                      help="Custom file pattern to save dataset to")
-    group.add_argument(
-        "--compress", action="store_true", help="zlib compress each netcdf file"
-    )
+    group.add_argument("--compress", action="store_true", help="zlib compress each netcdf file")
     group.add_argument("--fix-awips", action="store_true", help=argparse.SUPPRESS)
     # help="modify NetCDF output to work with the old/broken AWIPS NetCDF library")
     group.add_argument(
@@ -165,7 +170,6 @@ def add_writer_argument_groups(parser, group=None):
     group.add_argument(
         "--template",
         default="polar",
-        help="specify name for pre-configured template used to "
-        "determine output file structure and formatting.",
+        help="specify name for pre-configured template used to " "determine output file structure and formatting.",
     )
     return group, None

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -48,13 +48,15 @@ import dask.array as da
 logger = logging.getLogger(__name__)
 
 DEFAULT_OUTPUT_FILENAMES = {
-    None: "{platform_name!u}_{sensor!u}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
-    "abi_l1b": "{platform_name!u}_{sensor!u}_{observation_type}{scene_abbr}_"
-    "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
-    "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
-    "mirs": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
-    "clavrx": "{platform_name!l}_{sensor!l}_{name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
-    "virr_l1b": "{platform_name!l}_{sensor!l}_{name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+    "polar2grid": {
+        None: "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+    },
+    "geo2grid": {
+        None: "{platform_name!u}_{sensor!u}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+        "abi_l1b": "{platform_name!u}_{sensor!u}_{observation_type}{scene_abbr}_"
+        "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+        "clavrx": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.dat",
+    },
 }
 
 

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -47,14 +47,15 @@ LOG = logging.getLogger(__name__)
 
 # reader_name -> filename
 DEFAULT_OUTPUT_FILENAMES = {
-    None: "{platform_name!u}_{sensor!u}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "abi_l1b": "{platform_name!u}_{sensor!u}_{observation_type}{scene_abbr}_"
-    "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "viirs_sdr": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "mirs": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "clavrx": "{platform_name!l}_{sensor!l}_{name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "virr_l1b": "{platform_name!l}_{sensor!l}_{name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
-    "mersi2_l1b": "{platform_name!l}_{sensor!l}_{name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+    "polar2grid": {
+        None: "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+    },
+    "geo2grid": {
+        "abi_l1b": "{platform_name!u}_{sensor!u}_{observation_type}{scene_abbr}_"
+        "{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+        "clavrx": "{platform_name!l}_{sensor!l}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+        None: "{platform_name!u}_{sensor!u}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}_{area.area_id}.tif",
+    },
 }
 
 

--- a/polar2grid/writers/hdf5.py
+++ b/polar2grid/writers/hdf5.py
@@ -60,7 +60,14 @@ from polar2grid.writers.geotiff import NUMPY_DTYPE_STRS, NumpyDtypeList, str_to_
 LOG = logging.getLogger(__name__)
 
 # reader_name -> filename
-DEFAULT_OUTPUT_FILENAMES = {None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.h5"}
+DEFAULT_OUTPUT_FILENAMES = {
+    "polar2grid": {
+        None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.h5",
+    },
+    "geo2grid": {
+        None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.h5",
+    },
+}
 
 
 def all_equal(iterable: list[str]) -> bool:


### PR DESCRIPTION
This updates the choices that each writer has configured for what the output filename should be. Previously the choice was determined by what reader was being used. However, this resulted in having to update every writer when a new reader was added depending on if the reader was a Geo2Grid or Polar2Grid reader and how the writer's default filename was configured. This PR makes it so the decision has two levels: first by whether we are running Geo2Grid or Polar2Grid and then by reader. This allows Polar2Grid filenames (which are pretty consistent across all readers) to not need to be updated when a new reader is added while still having the slightly different Geo2Grid naming used by default when Geo2Grid is run.