### PR TITLE
Use mask_and_scale in comparison of netcdf

### DIFF
--- a/etc/resampling.yaml
+++ b/etc/resampling.yaml
@@ -6,6 +6,24 @@ resampling:
     area_type: area
     resampler: native
     default_target: MAX
+  default_clavrx_rain_rate:
+    name: rain_rate
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 1.0
+  default_clavrx_cld_height:
+    name: cld_height_acha
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 1.0
+  default_clavrx_temp:
+    name: cld_temp_acha
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 1.0
   default_viirs:
     area_type: swath
     sensor: viirs

--- a/etc/resampling.yaml
+++ b/etc/resampling.yaml
@@ -24,6 +24,12 @@ resampling:
     kwargs:
       weight_delta_max: 40.0
       weight_distance_max: 1.0
+  default_clavrx_cloud_phase:
+    name: cloud_phase
+    resampler: nearest
+  default_clavrx_cloud_type:
+    name: cloud_type
+    resampler: nearest
   default_viirs:
     area_type: swath
     sensor: viirs

--- a/polar2grid/compare.py
+++ b/polar2grid/compare.py
@@ -126,11 +126,10 @@ def plot_array(array1, array2, cmap="viridis", vmin=None, vmax=None, **kwargs):
     fig.colorbar(img2, ax=ax1[1])
 
     ax2[0].set_title("Difference")
-    inner_fence_low = q[1] - (q[3] - q[1]) * 1.5
-    inner_fence_high = q[3] + (q[3] - q[1]) * 1.5
-    img4 = ax2[0].imshow(array3, cmap=cmap, vmin=inner_fence_low, vmax=inner_fence_high)
+    array3[array3 == 0.0] = np.nan
+    img4 = ax2[0].imshow(array3, cmap=cmap)
     fig.colorbar(img4, ax=ax2[0])
-    fig.delaxes(ax2[1])
+    ax2[1].hist(array3[~np.isnan(array3)], 100)
 
     plt.tight_layout()
     plt.show()

--- a/polar2grid/compare.py
+++ b/polar2grid/compare.py
@@ -121,8 +121,6 @@ def plot_array(array1, array2, cmap="viridis", vmin=None, vmax=None, **kwargs):
 
     ax1[0].imshow(array1, cmap=cmap, vmin=vmin, vmax=vmax)
     ax1[1].imshow(array2, cmap=cmap, vmin=vmin, vmax=vmax)
-
-    
     diff_max = max(np.nanmax(array3),np.absolute(np.nanmin(array3)))
     img3 = ax2[0].imshow(array3, cmap='RdBu', vmin=-diff_max, vmax=diff_max)
     fig.colorbar(img3, ax=ax2[0])
@@ -138,7 +136,7 @@ def compare_array(array1, array2, plot=False, **kwargs) -> ArrayComparisonResult
     return isclose_array(array1, array2, **kwargs)
 
 
-def compare_binary(fn1, fn2, shape, dtype,  atol=0.0, margin_of_error=0.0, **kwargs) -> list[ArrayComparisonResult]:
+def compare_binary(fn1, fn2, shape, dtype, atol=0.0, margin_of_error=0.0, **kwargs) -> list[ArrayComparisonResult]:
     if dtype is None:
         dtype = np.float32
     mmap_kwargs = {"dtype": dtype, "mode": "r"}
@@ -174,7 +172,7 @@ def _get_geotiff_array(gtiff_fn, dtype=None):
     return arr
 
 
-def compare_awips_netcdf(nc1_name, nc2_name, conovert_nan=None, atol=0.0, margin_of_error=0.0, **kwargs) -> list[ArrayComparisonResult]:
+def compare_awips_netcdf(nc1_name, nc2_name, atol=0.0, margin_of_error=0.0, **kwargs) -> list[ArrayComparisonResult]:
     """Compare 2 8-bit AWIPS-compatible NetCDF3 files
 
     .. note::
@@ -290,7 +288,6 @@ class CompareHelper:
         if file_type is None:
             # guess based on file extension
             ext = os.path.splitext(file1)[-1]
-            file_type = file_ext_to_compare_func.get(ext)
             file_type = file_ext_to_compare_func.get(ext)
         if file_type is None:
             LOG.error(f"Could not determine how to compare file type (extension not recognized): {file1}.")

--- a/polar2grid/compare.py
+++ b/polar2grid/compare.py
@@ -109,10 +109,9 @@ def plot_array(array1, array2, cmap="viridis", vmin=None, vmax=None, **kwargs):
     import matplotlib.pyplot as plt
 
     LOG.info("Plotting arrays...")
-    if vmin is None:
-        vmin = min(np.nanmin(array1), np.nanmin(array2))
-        vmax = max(np.nanmax(array1), np.nanmax(array2))
-
+    vmin = vmin if vmin else -10
+    vmax = vmax if vmax else 10
+        
     fig, (ax1, ax2) = plt.subplots(2, 2)
     array3 = array1 - array2
     q = [0, 0.25, 0.5, 0.75, 1.0]
@@ -127,9 +126,12 @@ def plot_array(array1, array2, cmap="viridis", vmin=None, vmax=None, **kwargs):
 
     ax2[0].set_title("Difference")
     array3[array3 == 0.0] = np.nan
-    img4 = ax2[0].imshow(array3, cmap=cmap)
+    img4 = ax2[0].imshow(array3, cmap='RdBu', vmin=vmin, vmax=vmax)
     fig.colorbar(img4, ax=ax2[0])
-    ax2[1].hist(array3[~np.isnan(array3)], 100)
+
+    n_bins = 100
+    nan_array3 = array3[~np.isnan(array3)]
+    ax2[1].hist(nan_array3, density=True, bins=n_bins)
 
     plt.tight_layout()
     plt.show()

--- a/polar2grid/compare.py
+++ b/polar2grid/compare.py
@@ -103,7 +103,7 @@ def isclose_array(array1, array2, atol=0.0, rtol=0.0, margin_of_error=0.0, **kwa
     LOG.info("%d pixels out of %d pixels are different" % (diff_pixels, total_pixels))
     return ArrayComparisonResult(True, diff_pixels, total_pixels, False)
 
- 
+
 def plot_array(array1, array2, cmap="viridis", vmin=None, vmax=None, **kwargs):
     """Debug two arrays being different by visually comparing them."""
     import matplotlib.pyplot as plt
@@ -114,14 +114,14 @@ def plot_array(array1, array2, cmap="viridis", vmin=None, vmax=None, **kwargs):
         vmax = max(np.nanmax(array1), np.nanmax(array2))
 
     fig, (ax1, ax2) = plt.subplots(2, 2)
-    array3 = (array1 - array2)
-    q=[0,0.25,0.5, 0.75,1.0]
+    array3 = array1 - array2
+    q = [0, 0.25, 0.5, 0.75, 1.0]
     array3_quantiles = np.nanquantile(array3, q)
     fig.suptitle(array3_quantiles)
 
     ax1[0].imshow(array1, cmap=cmap, vmin=vmin, vmax=vmax)
     ax1[1].imshow(array2, cmap=cmap, vmin=vmin, vmax=vmax)
-    diff_max = max(np.nanmax(array3),np.absolute(np.nanmin(array3)))
+    diff_max = max(np.nanmax(array3), np.absolute(np.nanmin(array3)))
     img3 = ax2[0].imshow(array3, cmap='RdBu', vmin=-diff_max, vmax=diff_max)
     fig.colorbar(img3, ax=ax2[0])
     fig.delaxes(ax2[1])
@@ -194,14 +194,14 @@ def compare_awips_netcdf(nc1_name, nc2_name, atol=0.0, margin_of_error=0.0, **kw
 
     return [compare_array(image1_data, image2_data, atol=atol, margin_of_error=margin_of_error, **kwargs)]
 
+
 def compare_netcdf(
     nc1_name, nc2_name, variables, atol=0.0, margin_of_error=0.0, **kwargs
 ) -> list[VariableComparisonResult]:
-    from netCDF4 import Dataset
 
     nc1 = xr.open_dataset(nc1_name)
     nc2 = xr.open_dataset(nc2_name)
-    
+
     if variables is None:
         # TODO: Handle groups
         variables = list(nc1.variables.keys())


### PR DESCRIPTION
This PR updates the reading of netcdf files to use mask and scale (previously set to false).  xarray.open_dataset replaces netcdf4.Dataset so that mask, scale and fill are handled when read.  

file_type and plot keywords did not seem to be used previously, or something went wrong with my version, this PR updates the use of the --plot and file_type arguments.

the comparison plots were nice, but sometimes hard to know how severe the differences are by just looking at side to side plot.  This adds a nanquantile subtitle to the plots and a plot difference of array1 - array2.

Updates needed for clavrx resampling were found when testing this version of compare, these are added in this PR.  