### PR TITLE
Add --extra-config-path glue option and add_coastlines optional caching

### DIFF
--- a/doc/source/examples/acspo_example.rst
+++ b/doc/source/examples/acspo_example.rst
@@ -217,7 +217,7 @@ with a color bar in Degrees Celsius.
       --colorbar-text-size 20 --colorbar-height=35
 
 I can perform a similar conversion of the temperature range to 
-Degrees Fahrenheit and create an image with a color bar labelled 
+Degrees Fahrenheit and create an image with a color bar labeled
 in those units.
 
 .. code-block:: bash
@@ -247,7 +247,7 @@ I execute the command,
       --colorbar-text-size 20 --colorbar-height=35
 
 it will result in the creation of the final image product that 
-is a re-gridded, re-scaled, color enhanced image with a color bar labelled in
+is a re-gridded, re-scaled, color enhanced image with a color bar labeled in
 Degrees Celsius and coastline overlays. 
 
 .. raw:: latex

--- a/doc/source/examples/amsr2_example.rst
+++ b/doc/source/examples/amsr2_example.rst
@@ -66,7 +66,7 @@ and rescale the data using the test data set from 19 July 2016:
 
 .. code-block:: bash
 
-    polar2grid.sh amsr2_l1b gtiff --rescale-configs $POLAR2GRID_HOME/rescale_configs/amsr2_png.ini -g lcc_fit -f ../data/GW1AM2_201607191903_137A_L1DLBTBR_1110110.h5
+    polar2grid.sh amsr2_l1b gtiff --extra-config-path $POLAR2GRID_HOME/example_enhancements/amsr2_png -g lcc_fit -f ../data/GW1AM2_201607191903_137A_L1DLBTBR_1110110.h5
 
 Executing this command produces these AMSR2 LCC GeoTIFF files:
 

--- a/integration_tests/features/environment.py
+++ b/integration_tests/features/environment.py
@@ -12,7 +12,13 @@ def before_all(context):
     if not context.datapath.startswith(os.sep):
         context.datapath = os.path.join(os.getcwd(), context.datapath)
     p2g_home = os.environ.get("POLAR2GRID_HOME")
-    context.p2g_path = os.path.join(p2g_home, "bin") if p2g_home is not None else ""
+    # if POLAR2GRID_HOME isn't defined, assume things are installed in the python prefix
+    context.p2g_path = os.path.join(p2g_home, "bin") if p2g_home is not None else os.path.join(sys.prefix, "bin")
+    if p2g_home is None:
+        # assume development/editable install
+        import polar2grid
+
+        os.environ["POLAR2GRID_HOME"] = os.path.join(os.path.dirname(polar2grid.__file__), "..", "swbundle")
     tmpdir = tempfile.gettempdir()
     context.base_temp_dir = os.path.join(tmpdir, "p2g_integration_tests")
 

--- a/integration_tests/features/geo2grid.feature
+++ b/integration_tests/features/geo2grid.feature
@@ -4,6 +4,7 @@ Feature: Test geo2grid output images
 
   Scenario Outline: Test geo2grid images
     Given input data from <source>
+    Given an empty working directory
     When <command> runs
     Then the output matches with the files in <output>
 
@@ -16,6 +17,7 @@ Feature: Test geo2grid output images
 
   Scenario Outline: Test list products output
     Given input data from <source>
+    Given an empty working directory
     When <command> runs with --list-products
     Then the printed output includes the products in <output>
 

--- a/integration_tests/features/polar2grid.feature
+++ b/integration_tests/features/polar2grid.feature
@@ -12,6 +12,10 @@ Feature: Test polar2grid output images
       | command                                              | source            |  output            |
       | polar2grid.sh -r acspo -w geotiff -vv --grid-coverage=0.0 -f | acspo/input/test1 | acspo/output/test1 |
       | polar2grid.sh -r acspo -w geotiff -vv --grid-coverage=0.0 -f | acspo/input/test2 | acspo/output/test2 |
+      | polar2grid.sh -r acspo -w geotiff -vv --grid-coverage=0.0 -f | acspo/input/test3 | acspo/output/test3 |
+      | polar2grid.sh -r acspo -w geotiff -vv --grid-coverage=0.0 -f | acspo/input/test4 | acspo/output/test4 |
+      | polar2grid.sh -r acspo -w geotiff -vv --grid-coverage=0.0 -f | acspo/input/test5 | acspo/output/test5 |
+      | polar2grid.sh -r acspo -w geotiff -vv --grid-coverage=0.0 -f | acspo/input/test6 | acspo/output/test6 |
 
    Examples: AMSR2_L1B
       | command                                                                  | source            | output             |

--- a/integration_tests/features/polar2grid.feature
+++ b/integration_tests/features/polar2grid.feature
@@ -4,6 +4,7 @@ Feature: Test polar2grid output images
 
   Scenario Outline: Test polar2grid images
     Given input data from <source>
+    Given an empty working directory
     When <command> runs
     Then the output matches with the files in <output>
 
@@ -15,6 +16,8 @@ Feature: Test polar2grid output images
    Examples: AMSR2_L1B
       | command                                                                  | source            | output             |
       | polar2grid.sh -r amsr2_l1b -w awips_tiled -vv --sector-id LCC --source-name SSEC --letters -g 211e -p btemp_36.5h btemp_89.0av -f | amsr2/input/test1 | amsr2/output/test1 |
+      | polar2grid.sh -r amsr2_l1b -w geotiff -vv -f | amsr2/input/test1 | amsr2/output/test2 |
+      | polar2grid.sh -r amsr2_l1b -w geotiff --extra-config-path ${POLAR2GRID_HOME}/example_enhancements/amsr2_png -g lcc_fit -vv -f | amsr2/input/test1 | amsr2/output/test3 |
 
     Examples: AVHRR
       | command                          | source            | output             |
@@ -44,6 +47,7 @@ Feature: Test polar2grid output images
 
   Scenario Outline: Test list products output
     Given input data from <source>
+    Given an empty working directory
     When <command> runs with --list-products
     Then the printed output includes the products in <output>
 

--- a/integration_tests/features/steps/compare_images.py
+++ b/integration_tests/features/steps/compare_images.py
@@ -24,7 +24,7 @@ def step_impl(context, source):
         else:
             assert os.path.exists(f), "Input {} does not exist".format(f)
 
-    context.source = new_source
+    context.source = new_source.rstrip()
 
 
 @given("an empty working directory")
@@ -33,14 +33,15 @@ def step_impl(context):
 
 
 @given("input data is copied to the working directory")
-def step_impl(context, source):
+def step_impl(context):
     new_source = ""
-    for input_path in context.source.split(" "):
-        new_path = os.path.join(context.temp_dir, os.path.basename(input_path))
-        new_source += new_path + " "
-        shutil.copy(input_path, new_path)
+    for input_dir in context.source.split(" "):
+        for input_filename in os.listdir(input_dir):
+            new_path = os.path.join(context.temp_dir, os.path.basename(input_filename))
+            new_source += new_path + " "
+            shutil.copy(os.path.join(input_dir, input_filename), new_path)
 
-    context.source = new_source
+    context.source = new_source.rstrip()
 
 
 @when("{command} runs")

--- a/integration_tests/features/steps/compare_images.py
+++ b/integration_tests/features/steps/compare_images.py
@@ -27,18 +27,34 @@ def step_impl(context, source):
     context.source = new_source
 
 
+@given("an empty working directory")
+def step_impl(context):
+    context.temp_dir = tempfile.mkdtemp(prefix=os.path.join(context.base_temp_dir, "p2g_tests_"))
+
+
+@given("input data is copied to the working directory")
+def step_impl(context, source):
+    new_source = ""
+    for input_path in context.source.split(" "):
+        new_path = os.path.join(context.temp_dir, os.path.basename(input_path))
+        new_source += new_path + " "
+        shutil.copy(input_path, new_path)
+
+    context.source = new_source
+
+
 @when("{command} runs")
 def step_impl(context, command):
     context.script = command.split()[0]
     context.command = "datapath={}; /usr/bin/time {} {}".format(
-        context.datapath, os.path.join(context.p2g_path, command), context.source
+        context.datapath, os.path.join(context.p2g_path, os.path.expandvars(command)), context.source
     )
 
     # creating new data in temporary directory to compare
     orig_dir = os.getcwd()
+    temp_dir = getattr(context, "temp_dir", orig_dir)
     try:
-        context.temp_dir = tempfile.mkdtemp(prefix=os.path.join(context.base_temp_dir, "p2g_tests_"))
-        os.chdir(context.temp_dir)
+        os.chdir(temp_dir)
         exit_status = subprocess.call(context.command, shell=True)
         assert exit_status == 0, "{} ran unsuccessfully".format(context.command)
     finally:

--- a/integration_tests/features/utilities.feature
+++ b/integration_tests/features/utilities.feature
@@ -11,4 +11,19 @@ Feature: Test polar2grid utility scripts
 
     Examples: AMSR2_L1B
       | command                                                                  | source            | output             |
-      | add_colormap.sh ${POLAR2GRID_HOME}/colormaps/amsr2_89h.cmap | utilities/add_colormap/input/test1 | utilities/add_colormap/output/test1 |
+      | add_colormap.sh ${POLAR2GRID_HOME}/colormaps/amsr2_89h.cmap | add_colormap/input/test1 | add_colormap/output/test1 |
+
+    Examples: ACSPO
+      | command                                                                  | source            | output             |
+      | add_colormap.sh ${POLAR2GRID_HOME}/colormaps/p2g_sst_palette.txt | add_colormap/input/test2 | add_colormap/output/test2 |
+
+  Scenario Outline: Test add_coastlines.sh
+    Given input data from <source>
+    Given an empty working directory
+    Given input data is copied to the working directory
+    When <command> runs
+    Then the output matches with the files in <output>
+
+    Examples: ACSPO
+      | command                                                                  | source            | output             |
+      | add_coastlines.sh --add-colorbar --colorbar-text-color="white" --colorbar-units="K" --colorbar-align top --colorbar-title="VIIRS ACSPO SST" --colorbar-text-size 20 --colorbar-height=35 --add-coastlines --add-borders --  | add_coastlines/input/test1 | add_coastlines/output/test1 |

--- a/integration_tests/features/utilities.feature
+++ b/integration_tests/features/utilities.feature
@@ -1,0 +1,14 @@
+Feature: Test polar2grid utility scripts
+  This takes test data from source and runs it through the command provided.
+  It then compares the new image with the expected output.
+
+  Scenario Outline: Test add_colormap.sh
+    Given input data from <source>
+    Given an empty working directory
+    Given input data is copied to the working directory
+    When <command> runs
+    Then the output matches with the files in <output>
+
+    Examples: AMSR2_L1B
+      | command                                                                  | source            | output             |
+      | add_colormap.sh ${POLAR2GRID_HOME}/colormaps/amsr2_89h.cmap | utilities/add_colormap/input/test1 | utilities/add_colormap/output/test1 |

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -148,7 +148,8 @@ run_tests()
 
     # Prints output to stdout and to an output file. Note that datapath MUST be specified.
     behave "${WORKSPACE}/integration_tests/features" --no-logcapture --no-color\
-     --no-capture -D datapath=/data/test_data -D html_dst="${WORKSPACE}" -i "${prefix}2grid.feature" --format pretty\
+     --no-capture -D datapath=/data/test_data -D html_dst="${WORKSPACE}" -i "${prefix}2grid.feature"\
+     -i "utilities.feature" --format pretty\
      --format json.pretty 2>&1 | tee "$test_output" || status=$?
     # Still makes test details even if not all tests pass.
     format_test_details "$prefix" "$test_output"

--- a/polar2grid/add_coastlines.py
+++ b/polar2grid/add_coastlines.py
@@ -387,7 +387,7 @@ def main():
         # P = palette which we assume to be an RGBA colormap
         img = img.convert("RGBA" if num_bands in (2, 4) or "P" in img_bands else "RGB")
         if pycoast_options:
-            area_id = os.path.splitext(input_tiff[0])
+            area_id = os.path.splitext(input_tiff[0])[0]
             area_def = get_area_def_from_raster(input_tiff, area_id=area_id)
             cw = ContourWriterAGG(args.shapes_dir)
             cw.add_overlay_from_dict(pycoast_options, area_def, background=img)

--- a/polar2grid/add_coastlines.py
+++ b/polar2grid/add_coastlines.py
@@ -42,11 +42,10 @@ import os
 import sys
 import logging
 from pycoast import ContourWriterAGG
+from pyresample.utils import get_area_def_from_raster
 from PIL import Image, ImageFont
 from aggdraw import Font
-# XXX: For some reason 'gdal' needs to be imported *after* PIL otherwise we get a segfault
-import gdal
-import osr
+import rasterio
 import numpy as np
 
 
@@ -57,32 +56,37 @@ except ImportError:
     print("WARNING: Missing 'pkg_resources' dependency")
 
     def get_resource_filename(mod_name, resource_name):
-        if mod_name != 'polar2grid.fonts':
-            raise ValueError('Can only import resources from polar2grid (missing pkg_resources dependency)')
-        return os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'fonts', resource_name)
+        if mod_name != "polar2grid.fonts":
+            raise ValueError("Can only import resources from polar2grid (missing pkg_resources dependency)")
+        return os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "fonts", resource_name)
+
 
 LOG = logging.getLogger(__name__)
 PYCOAST_DIR = os.environ.get("GSHHS_DATA_ROOT")
 
 
-def get_colormap(band, band_count):
+def get_colormap(band_dtype, band_ct, band_count):
     from trollimage.colormap import Colormap
-    ct = band.GetRasterColorTable()
-    data = band.ReadAsArray()
-    max_val = np.iinfo(data.dtype).max
+
+    max_val = np.iinfo(band_dtype).max
     # if we have an alpha band then include the entire colormap
     # otherwise assume it is using 0 as a fill value
     start_idx = 1 if band_count == 1 else 0
-    if ct is None:
+    if band_ct is None:
         # NOTE: the comma is needed to make this a tuple
-        color_iter = (
-            (idx / float(max_val), (int(idx / float(max_val)),) * 3 + (1.0,)) for idx in range(max_val))
+        color_iter = ((idx / float(max_val), (int(idx / float(max_val)),) * 3 + (1.0,)) for idx in range(max_val))
     else:
-        color_iter = ((idx / float(max_val), ct.GetColorEntry(idx))
-                      for idx in range(start_idx, ct.GetCount()))
+        color_iter = ((idx / float(max_val), color) for idx, color in sorted(band_ct.items())[start_idx:])
         color_iter = ((idx, tuple(x / float(max_val) for x in color)) for idx, color in color_iter)
     cmap = Colormap(*color_iter)
     return cmap
+
+
+def _get_rio_colormap(rio_ds, bidx):
+    try:
+        return rio_ds.colormap(bidx)
+    except ValueError:
+        return None
 
 
 def find_font(font_name, size):
@@ -90,124 +94,260 @@ def find_font(font_name, size):
         font = ImageFont.truetype(font_name, size)
         return font.path
     except IOError:
-        font_path = get_resource_filename('polar2grid.fonts', font_name)
+        font_path = get_resource_filename("polar2grid.fonts", font_name)
         if not os.path.exists(font_path):
             raise ValueError("Font path does not exist: {}".format(font_path))
         return font_path
 
 
+def _args_to_pycoast_dict(args):
+    opts = {}
+    if args.add_coastlines:
+        outline = (
+            args.coastlines_outline[0]
+            if len(args.coastlines_outline) == 1
+            else tuple(int(x) for x in args.coastlines_outline)
+        )
+        if args.coastlines_fill:
+            fill = (
+                args.coastlines_fill[0]
+                if len(args.coastlines_fill) == 1
+                else tuple(int(x) for x in args.coastlines_fill)
+            )
+        else:
+            fill = None
+        opts["coasts"] = {
+            "resolution": args.coastlines_resolution,
+            "level": args.coastlines_level,
+            "width": args.coastlines_width,
+            "outline": outline,
+            "fill": fill,
+        }
+
+    if args.add_rivers:
+        outline = (
+            args.rivers_outline[0] if len(args.rivers_outline) == 1 else tuple(int(x) for x in args.rivers_outline)
+        )
+        opts["rivers"] = {
+            "resolution": args.rivers_resolution,
+            "level": args.rivers_level,
+            "width": args.rivers_width,
+            "outline": outline,
+        }
+
+    if args.add_borders:
+        outline = (
+            args.borders_outline[0] if len(args.borders_outline) == 1 else tuple(int(x) for x in args.borders_outline)
+        )
+        opts["borders"] = {
+            "resolution": args.borders_resolution,
+            "level": args.borders_level,
+            "width": args.borders_width,
+            "outline": outline,
+        }
+
+    if args.add_grid:
+        outline = args.grid_outline[0] if len(args.grid_outline) == 1 else tuple(int(x) for x in args.grid_outline)
+        minor_outline = (
+            args.grid_minor_outline[0]
+            if len(args.grid_minor_outline) == 1
+            else tuple(int(x) for x in args.grid_minor_outline)
+        )
+        fill = args.grid_fill[0] if len(args.grid_fill) == 1 else tuple(int(x) for x in args.grid_fill)
+        font_path = find_font(args.grid_font, args.grid_text_size)
+        font = Font(outline, font_path, size=args.grid_text_size)
+        opts["grid"] = {
+            "lon_major": args.grid_D[0],
+            "lat_major": args.grid_D[1],
+            "lon_minor": args.grid_d[0],
+            "lat_minor": args.grid_d[1],
+            "font": font,
+            "fill": fill,
+            "outline": outline,
+            "minor_outline": minor_outline,
+            "write_text": args.grid_text,
+            "width": args.grid_width,
+            "lon_placement": args.grid_lon_placement,
+            "lat_placement": args.grid_lat_placement,
+        }
+
+    if args.cache_dir:
+        opts["cache"] = {
+            # add "add_coastlines" prefix to cached image name
+            "file": os.path.join(args.cache_dir, "add_coastlines"),
+            "regenerate": args.cache_regenerate,
+        }
+
+    return opts
+
+
 def get_parser():
     import argparse
-    parser = argparse.ArgumentParser(description="Add overlays to a GeoTIFF file and save as a PNG file.",
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser = argparse.ArgumentParser(
+        description="Add overlays to a GeoTIFF file and save as a PNG file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     group = parser.add_argument_group("coastlines")
-    group.add_argument("--add-coastlines", action="store_true",
-                       help="Add coastlines")
-    group.add_argument("--coastlines-resolution", choices="clihf", default='i',
-                       help="Resolution of coastlines to add (crude, low, intermediate, high, full)")
-    group.add_argument("--coastlines-level", choices=range(1, 7), type=int, default=4,
-                       help="Level of detail from the selected resolution dataset")
-    group.add_argument("--coastlines-outline", default=["yellow"], nargs="*",
-                       help="Color of coastline lines (color name or 3 RGB integers)")
-    group.add_argument("--coastlines-fill", default=None, nargs="*",
-                       help="Color of land")
-    group.add_argument("--coastlines-width", default=1.0, type=float,
-                       help="Width of coastline lines")
+    group.add_argument("--add-coastlines", action="store_true", help="Add coastlines")
+    group.add_argument(
+        "--coastlines-resolution",
+        choices="clihf",
+        default="i",
+        help="Resolution of coastlines to add (crude, low, intermediate, high, full)",
+    )
+    group.add_argument(
+        "--coastlines-level",
+        choices=range(1, 7),
+        type=int,
+        default=4,
+        help="Level of detail from the selected resolution dataset",
+    )
+    group.add_argument(
+        "--coastlines-outline",
+        default=["yellow"],
+        nargs="*",
+        help="Color of coastline lines (color name or 3 RGB integers)",
+    )
+    group.add_argument("--coastlines-fill", default=None, nargs="*", help="Color of land")
+    group.add_argument("--coastlines-width", default=1.0, type=float, help="Width of coastline lines")
 
     group = parser.add_argument_group("rivers")
-    group.add_argument("--add-rivers", action="store_true",
-                       help="Add rivers grid")
-    group.add_argument("--rivers-resolution", choices="clihf", default='c',
-                       help="Resolution of rivers to add (crude, low, intermediate, high, full)")
-    group.add_argument("--rivers-level", choices=range(0, 11), type=int, default=5,
-                       help="Level of detail for river lines")
-    group.add_argument("--rivers-outline", default=['blue'], nargs="*",
-                       help="Color of river lines (color name or 3 RGB integers)")
-    group.add_argument("--rivers-width", default=1.0, type=float,
-                       help="Width of rivers lines")
+    group.add_argument("--add-rivers", action="store_true", help="Add rivers grid")
+    group.add_argument(
+        "--rivers-resolution",
+        choices="clihf",
+        default="c",
+        help="Resolution of rivers to add (crude, low, intermediate, high, full)",
+    )
+    group.add_argument(
+        "--rivers-level", choices=range(0, 11), type=int, default=5, help="Level of detail for river lines"
+    )
+    group.add_argument(
+        "--rivers-outline", default=["blue"], nargs="*", help="Color of river lines (color name or 3 RGB integers)"
+    )
+    group.add_argument("--rivers-width", default=1.0, type=float, help="Width of rivers lines")
 
     group = parser.add_argument_group("grid")
-    group.add_argument("--add-grid", action="store_true",
-                       help="Add lat/lon grid")
-    group.add_argument("--grid-no-text", dest='grid_text', action="store_false",
-                       help="Add labels to lat/lon grid")
-    group.add_argument("--grid-text-size", default=32, type=int,
-                       help="Lat/lon grid text font size")
-    group.add_argument("--grid-font", default="Vera.ttf",
-                       help="Path to TTF font (package provided or custom path)")
-    group.add_argument("--grid-fill", nargs="*", default=["cyan"],
-                       help="Color of grid text (color name or 3 RGB integers)")
-    group.add_argument("--grid-outline", nargs="*", default=["cyan"],
-                       help="Color of grid lines (color name or 3 RGB integers)")
-    group.add_argument("--grid-minor-outline", nargs="*", default=["cyan"],
-                       help="Color of tick lines (color name or 3 RGB integers)")
-    group.add_argument("--grid-D", nargs=2, default=(10., 10.), type=float,
-                       help="Degrees between grid lines (lon, lat)")
-    group.add_argument("--grid-d", nargs=2, default=(2., 2.), type=float,
-                       help="Degrees between tick lines (lon, lat)")
-    group.add_argument("--grid-lon-placement", choices=["tl", "lr", "lc", "cc"], default="tb",
-                       help="Longitude label placement")
-    group.add_argument("--grid-lat-placement", choices=["tl", "lr", "lc", "cc"], default="lr",
-                       help="Latitude label placement")
-    group.add_argument("--grid-width", default=1.0, type=float,
-                       help="Width of grid lines")
+    group.add_argument("--add-grid", action="store_true", help="Add lat/lon grid")
+    group.add_argument("--grid-no-text", dest="grid_text", action="store_false", help="Add labels to lat/lon grid")
+    group.add_argument("--grid-text-size", default=32, type=int, help="Lat/lon grid text font size")
+    group.add_argument("--grid-font", default="Vera.ttf", help="Path to TTF font (package provided or custom path)")
+    group.add_argument(
+        "--grid-fill", nargs="*", default=["cyan"], help="Color of grid text (color name or 3 RGB integers)"
+    )
+    group.add_argument(
+        "--grid-outline", nargs="*", default=["cyan"], help="Color of grid lines (color name or 3 RGB integers)"
+    )
+    group.add_argument(
+        "--grid-minor-outline", nargs="*", default=["cyan"], help="Color of tick lines (color name or 3 RGB integers)"
+    )
+    group.add_argument(
+        "--grid-D", nargs=2, default=(10.0, 10.0), type=float, help="Degrees between grid lines (lon, lat)"
+    )
+    group.add_argument(
+        "--grid-d", nargs=2, default=(2.0, 2.0), type=float, help="Degrees between tick lines (lon, lat)"
+    )
+    group.add_argument(
+        "--grid-lon-placement", choices=["tl", "lr", "lc", "cc"], default="tb", help="Longitude label placement"
+    )
+    group.add_argument(
+        "--grid-lat-placement", choices=["tl", "lr", "lc", "cc"], default="lr", help="Latitude label placement"
+    )
+    group.add_argument("--grid-width", default=1.0, type=float, help="Width of grid lines")
 
     group = parser.add_argument_group("borders")
-    group.add_argument("--add-borders", action="store_true",
-                       help="Add country and/or region borders")
-    group.add_argument("--borders-resolution", choices="clihf", default='i',
-                       help="Resolution of borders to add (crude, low, intermediate, high, full)")
-    group.add_argument("--borders-level", choices=range(1, 4), default=2, type=int,
-                       help="Level of detail for border lines")
-    group.add_argument("--borders-outline", default=['white'], nargs="*",
-                       help="Color of border lines (color name or 3 RGB integers)")
-    group.add_argument("--borders-width", default=1.0, type=float,
-                       help="Width of border lines")
+    group.add_argument("--add-borders", action="store_true", help="Add country and/or region borders")
+    group.add_argument(
+        "--borders-resolution",
+        choices="clihf",
+        default="i",
+        help="Resolution of borders to add (crude, low, intermediate, high, full)",
+    )
+    group.add_argument(
+        "--borders-level", choices=range(1, 4), default=2, type=int, help="Level of detail for border lines"
+    )
+    group.add_argument(
+        "--borders-outline", default=["white"], nargs="*", help="Color of border lines (color name or 3 RGB integers)"
+    )
+    group.add_argument("--borders-width", default=1.0, type=float, help="Width of border lines")
 
     group = parser.add_argument_group("colorbar")
-    group.add_argument("--add-colorbar", action="store_true",
-                       help="Add colorbar on top of image")
-    group.add_argument("--colorbar-width", type=int,
-                       help="Number of pixels wide")
-    group.add_argument("--colorbar-height", type=int,
-                       help="Number of pixels high")
-    group.add_argument("--colorbar-extend", action="store_true",
-                       help="Extend colorbar to full width/height of the image")
-    group.add_argument("--colorbar-tick-marks", type=float, default=5.0,
-                       help="Tick interval in data units")
-    group.add_argument("--colorbar-text-size", default=32, type=int,
-                       help="Tick label font size")
-    group.add_argument("--colorbar-text-color", nargs="*", default=['black'],
-                       help="Color of tick text (color name or 3 RGB integers)")
-    group.add_argument("--colorbar-font", default="Vera.ttf",
-                       help="Path to TTF font (package provided or custom path)")
-    group.add_argument("--colorbar-align", choices=['left', 'top', 'right', 'bottom'], default='bottom',
-                       help="Which direction to align colorbar (see --colorbar-vertical)")
-    group.add_argument('--colorbar-vertical', action='store_true',
-                       help="Position the colorbar vertically")
-    group.add_argument('--colorbar-no-ticks', dest='colorbar_ticks', action='store_false',
-                       help="Don't include ticks and tick labels on colorbar")
-    group.add_argument('--colorbar-min', type=float,
-                       help="Minimum data value of the colorbar."
-                            " Defaults to 'min_in' of input metadata or"
-                            " minimum value of the data otherwise.")
-    group.add_argument('--colorbar-max', type=float,
-                       help="Maximum data value of the colorbar."
-                            " Defaults to 'max_in' of input metadata or"
-                            " maximum value of the data otherwise.")
-    group.add_argument('--colorbar-units',
-                       help="Units marker to include in the colorbar text")
-    group.add_argument('--colorbar-title',
-                       help="Title shown with the colorbar")
+    group.add_argument("--add-colorbar", action="store_true", help="Add colorbar on top of image")
+    group.add_argument("--colorbar-width", type=int, help="Number of pixels wide")
+    group.add_argument("--colorbar-height", type=int, help="Number of pixels high")
+    group.add_argument(
+        "--colorbar-extend", action="store_true", help="Extend colorbar to full width/height of the image"
+    )
+    group.add_argument("--colorbar-tick-marks", type=float, default=5.0, help="Tick interval in data units")
+    group.add_argument("--colorbar-text-size", default=32, type=int, help="Tick label font size")
+    group.add_argument(
+        "--colorbar-text-color", nargs="*", default=["black"], help="Color of tick text (color name or 3 RGB integers)"
+    )
+    group.add_argument("--colorbar-font", default="Vera.ttf", help="Path to TTF font (package provided or custom path)")
+    group.add_argument(
+        "--colorbar-align",
+        choices=["left", "top", "right", "bottom"],
+        default="bottom",
+        help="Which direction to align colorbar (see --colorbar-vertical)",
+    )
+    group.add_argument("--colorbar-vertical", action="store_true", help="Position the colorbar vertically")
+    group.add_argument(
+        "--colorbar-no-ticks",
+        dest="colorbar_ticks",
+        action="store_false",
+        help="Don't include ticks and tick labels on colorbar",
+    )
+    group.add_argument(
+        "--colorbar-min",
+        type=float,
+        help="Minimum data value of the colorbar."
+        " Defaults to 'min_in' of input metadata or"
+        " minimum value of the data otherwise.",
+    )
+    group.add_argument(
+        "--colorbar-max",
+        type=float,
+        help="Maximum data value of the colorbar."
+        " Defaults to 'max_in' of input metadata or"
+        " maximum value of the data otherwise.",
+    )
+    group.add_argument("--colorbar-units", help="Units marker to include in the colorbar text")
+    group.add_argument("--colorbar-title", help="Title shown with the colorbar")
 
-    parser.add_argument("--shapes-dir", default=PYCOAST_DIR,
-                        help="Specify alternative directory for coastline shape files (default: GSHSS_DATA_ROOT)")
-    parser.add_argument("-o", "--output", dest="output_filename", nargs="+",
-                        help="Specify the output filename (default replace '.tif' with '.png')")
-    parser.add_argument('-v', '--verbose', dest='verbosity', action="count", default=0,
-                        help='each occurrence increases verbosity 1 level through ERROR-WARNING-INFO-DEBUG (default INFO)')
-    parser.add_argument("input_tiff", nargs="+",
-                        help="Input geotiff(s) to process")
+    parser.add_argument(
+        "--shapes-dir",
+        default=PYCOAST_DIR,
+        help="Specify alternative directory for coastline shape files (default: GSHSS_DATA_ROOT)",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Specify directory where cached coastline output can be stored and accessed in later "
+        "executions. The cache will never be cleared by this script. Caching depends on the grid "
+        "of the image and the decorations added to the image.",
+    )
+    parser.add_argument(
+        "--cache-regenerate",
+        action="store_true",
+        help="Force regeneration of any cached overlays. Requires '--cache-dir'.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output_filename",
+        nargs="+",
+        help="Specify the output filename (default replace '.tif' with '.png')",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbosity",
+        action="count",
+        default=0,
+        help="each occurrence increases verbosity 1 level through ERROR-WARNING-INFO-DEBUG (default INFO)",
+    )
+    parser.add_argument("input_tiff", nargs="+", help="Input geotiff(s) to process")
 
     return parser
 
@@ -222,107 +362,76 @@ def main():
     if args.output_filename is None:
         args.output_filename = [x[:-3] + "png" for x in args.input_tiff]
     else:
-        assert len(args.output_filename) == len(args.input_tiff), "Output filenames must be equal to number of input tiffs"
+        assert len(args.output_filename) == len(
+            args.input_tiff
+        ), "Output filenames must be equal to number of input tiffs"
 
-    if not (args.add_borders or args.add_coastlines or args.add_grid or
-            args.add_rivers or args.add_colorbar):
+    if not (args.add_borders or args.add_coastlines or args.add_grid or args.add_rivers or args.add_colorbar):
         LOG.error("Please specify one of the '--add-X' options to modify the image")
         return -1
+
+    if args.cache_dir and not os.path.isdir(args.cache_dir):
+        LOG.info(f"Creating cache directory: {args.cache_dir}")
+        os.makedirs(args.cache_dir, exist_ok=True)
 
     # we may be dealing with large images that look like decompression bombs
     # let's turn off the check for the image size in PIL/Pillow
     Image.MAX_IMAGE_PIXELS = None
-
+    # gather all options into a single dictionary that we can pass to pycoast
+    pycoast_options = _args_to_pycoast_dict(args)
     for input_tiff, output_filename in zip(args.input_tiff, args.output_filename):
         LOG.info("Creating {} from {}".format(output_filename, input_tiff))
-        gtiff = gdal.Open(input_tiff)
-        proj4_str = osr.SpatialReference(gtiff.GetProjection()).ExportToProj4()
-        ul_x, res_x, _, ul_y, _, res_y = gtiff.GetGeoTransform()
-        half_pixel_x = res_x / 2.
-        half_pixel_y = res_y / 2.
-        area_extent = (
-            ul_x - half_pixel_x,  # lower-left X
-            ul_y + res_y * gtiff.RasterYSize - half_pixel_y,  # lower-left Y
-            ul_x + res_x * gtiff.RasterXSize + half_pixel_x,  # upper-right X
-            ul_y + half_pixel_y,  # upper-right Y
-        )
-        img = Image.open(input_tiff).convert('RGBA' if gtiff.RasterCount in (2, 4) else 'RGB')
-        area_def = (proj4_str, area_extent)
-
-        cw = ContourWriterAGG(args.shapes_dir)
-
-        if args.add_coastlines:
-            outline = args.coastlines_outline[0] if len(args.coastlines_outline) == 1 else tuple(int(x) for x in args.coastlines_outline)
-            if args.coastlines_fill:
-                fill = args.coastlines_fill[0] if len(args.coastlines_fill) == 1 else tuple(int(x) for x in args.coastlines_fill)
-            else:
-                fill = None
-            cw.add_coastlines(img, area_def, resolution=args.coastlines_resolution,
-                              level=args.coastlines_level, width=args.coastlines_width,
-                              outline=outline, fill=fill)
-
-        if args.add_rivers:
-            outline = args.rivers_outline[0] if len(args.rivers_outline) == 1 else tuple(int(x) for x in args.rivers_outline)
-            cw.add_rivers(img, area_def,
-                          resolution=args.rivers_resolution, level=args.rivers_level,
-                          width=args.rivers_width, outline=outline)
-
-        if args.add_borders:
-            outline = args.borders_outline[0] if len(args.borders_outline) == 1 else tuple(int(x) for x in args.borders_outline)
-            cw.add_borders(img, area_def, resolution=args.borders_resolution, level=args.borders_level, outline=outline,
-                           width=args.borders_width)
-
-        if args.add_grid:
-            outline = args.grid_outline[0] if len(args.grid_outline) == 1 else tuple(int(x) for x in args.grid_outline)
-            minor_outline = args.grid_minor_outline[0] if len(args.grid_minor_outline) == 1 else tuple(int(x) for x in args.grid_minor_outline)
-            fill = args.grid_fill[0] if len(args.grid_fill) == 1 else tuple(int(x) for x in args.grid_fill)
-            font_path = find_font(args.grid_font, args.grid_text_size)
-            font = Font(outline, font_path, size=args.grid_text_size)
-            cw.add_grid(img, area_def, args.grid_D, args.grid_d, font,
-                        fill=fill, outline=outline, minor_outline=minor_outline,
-                        write_text=args.grid_text, width=args.grid_width,
-                        lon_placement=args.grid_lon_placement,
-                        lat_placement=args.grid_lat_placement)
+        img = Image.open(input_tiff)
+        img_bands = img.getbands()
+        num_bands = len(img_bands)
+        # P = palette which we assume to be an RGBA colormap
+        img = img.convert("RGBA" if num_bands in (2, 4) or "P" in img_bands else "RGB")
+        if pycoast_options:
+            area_id = os.path.splitext(input_tiff[0])
+            area_def = get_area_def_from_raster(input_tiff, area_id=area_id)
+            cw = ContourWriterAGG(args.shapes_dir)
+            cw.add_overlay_from_dict(pycoast_options, area_def, background=img)
 
         if args.add_colorbar:
             from pydecorate import DecoratorAGG
+
             font_color = args.colorbar_text_color
             font_color = font_color[0] if len(font_color) == 1 else tuple(int(x) for x in font_color)
             font_path = find_font(args.colorbar_font, args.colorbar_text_size)
             # this actually needs an aggdraw font
             font = Font(font_color, font_path, size=args.colorbar_text_size)
-            band_count = gtiff.RasterCount
-            if band_count not in [1, 2]:
+            if num_bands not in (1, 2):
                 raise ValueError("Can't add colorbar to RGB/RGBA image")
 
             # figure out what colormap we are dealing with
-            band = gtiff.GetRasterBand(1)
-            cmap = get_colormap(band, band_count)
+            rio_ds = rasterio.open(input_tiff)
+            input_dtype = np.dtype(rio_ds.meta["dtype"])
+            rio_ct = _get_rio_colormap(rio_ds, 1)
+            cmap = get_colormap(input_dtype, rio_ct, num_bands)
 
             # figure out our limits
             vmin = args.colorbar_min
             vmax = args.colorbar_max
-            metadata = gtiff.GetMetadata_Dict()
-            vmin = vmin or metadata.get('min_in')
-            vmax = vmax or metadata.get('max_in')
+            metadata = rio_ds.tags()
+            vmin = vmin or metadata.get("min_in")
+            vmax = vmax or metadata.get("max_in")
             if isinstance(vmin, str):
                 vmin = float(vmin)
             if isinstance(vmax, str):
                 vmax = float(vmax)
             if vmin is None or vmax is None:
-                data = gtiff.GetRasterBand(1).ReadAsArray()
-                vmin = vmin or np.iinfo(data.dtype).min
-                vmax = vmax or np.iinfo(data.dtype).max
+                vmin = vmin or np.iinfo(input_dtype).min
+                vmax = vmax or np.iinfo(input_dtype).max
             cmap.set_range(vmin, vmax)
 
             dc = DecoratorAGG(img)
-            if args.colorbar_align == 'top':
+            if args.colorbar_align == "top":
                 dc.align_top()
-            elif args.colorbar_align == 'bottom':
+            elif args.colorbar_align == "bottom":
                 dc.align_bottom()
-            elif args.colorbar_align == 'left':
+            elif args.colorbar_align == "left":
                 dc.align_left()
-            elif args.colorbar_align == 'right':
+            elif args.colorbar_align == "right":
                 dc.align_right()
 
             if args.colorbar_vertical:
@@ -331,21 +440,25 @@ def main():
                 dc.write_horizontally()
 
             if args.colorbar_width is None or args.colorbar_height is None:
-                LOG.warning("'--colorbar-width' or '--colorbar-height' were "
-                            "not specified. Forcing '--colorbar-extend'.")
+                LOG.warning(
+                    "'--colorbar-width' or '--colorbar-height' were " "not specified. Forcing '--colorbar-extend'."
+                )
                 args.colorbar_extend = True
             kwargs = {}
             if args.colorbar_width:
-                kwargs['width'] = args.colorbar_width
+                kwargs["width"] = args.colorbar_width
             if args.colorbar_height:
-                kwargs['height'] = args.colorbar_height
-            dc.add_scale(cmap, extend=args.colorbar_extend,
-                         font=font,
-                         line=font_color,
-                         tick_marks=args.colorbar_tick_marks,
-                         title=args.colorbar_title,
-                         unit=args.colorbar_units,
-                         **kwargs)
+                kwargs["height"] = args.colorbar_height
+            dc.add_scale(
+                cmap,
+                extend=args.colorbar_extend,
+                font=font,
+                line=font_color,
+                tick_marks=args.colorbar_tick_marks,
+                title=args.colorbar_title,
+                unit=args.colorbar_units,
+                **kwargs,
+            )
 
         img.save(output_filename)
 

--- a/polar2grid/add_colormap.py
+++ b/polar2grid/add_colormap.py
@@ -108,11 +108,15 @@ def parse_color_table_file(f):
                 interp_idx = 0
                 while prev_idx < parts[0]:
                     prev_idx += 1
-                    ct.append([prev_idx,
-                               r_interp[interp_idx],
-                               g_interp[interp_idx],
-                               b_interp[interp_idx],
-                               a_interp[interp_idx]])
+                    ct.append(
+                        [
+                            prev_idx,
+                            r_interp[interp_idx],
+                            g_interp[interp_idx],
+                            b_interp[interp_idx],
+                            a_interp[interp_idx],
+                        ]
+                    )
                     interp_idx += 1
             else:
                 ct.append(parts)
@@ -132,17 +136,19 @@ def load_color_table_file_to_colormap(ct_file):
 
     """
     from trollimage.colormap import Colormap
-    p2g_home = os.getenv('POLAR2GRID_HOME', '')
+
+    p2g_home = os.getenv("POLAR2GRID_HOME", "")
     ct_file = ct_file.replace("$POLAR2GRID_HOME", p2g_home)
     ct_file = ct_file.replace("$GEO2GRID_HOME", p2g_home)
-    if ct_file.endswith('.npy') or ct_file.endswith('.npz'):
+    if ct_file.endswith(".npy") or ct_file.endswith(".npz"):
         # binary colormap files (RGB, RGBA, VRGB, VRGBA)
         from satpy.enhancements import create_colormap
-        cmap = create_colormap({'filename': ct_file})
+
+        cmap = create_colormap({"filename": ct_file})
     else:
         # P2G style colormap text files
         ct = parse_color_table_file(ct_file)
-        entries = ((e[0] / 255., [x / 255. for x in e[1:]]) for e in ct)
+        entries = ((e[0] / 255.0, [x / 255.0 for x in e[1:]]) for e in ct)
         cmap = Colormap(*entries)
     return cmap
 
@@ -153,7 +159,7 @@ def create_colortable(ct_file_or_entries):
         ct_entries = parse_color_table_file(ct_file_or_entries)
     elif isinstance(ct_file_or_entries, Colormap):
         ct_entries = enumerate(ct_file_or_entries.colors)
-        ct_entries = (((x,) + tuple(int(c * 255.) for c in color)) for x, color in ct_entries)
+        ct_entries = (((x,) + tuple(int(c * 255.0) for c in color)) for x, color in ct_entries)
     else:
         ct_entries = ct_file_or_entries
 
@@ -175,12 +181,11 @@ def add_colortable(gtiff, ct):
 
 def get_parser():
     import argparse
+
     description = "Add a GeoTIFF colortable to an existing single-band GeoTIFF."
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("ct_file",
-                        help="Color table file to apply (CSV of (int, R, G, B, A)")
-    parser.add_argument("geotiffs", nargs="+",
-                        help="Geotiff files to apply the color table to")
+    parser.add_argument("ct_file", help="Color table file to apply (CSV of (int, R, G, B, A)")
+    parser.add_argument("geotiffs", nargs="+", help="Geotiff files to apply the color table to")
     return parser
 
 
@@ -192,6 +197,7 @@ def main():
     for geotiff_fn in args.geotiffs:
         gtiff = gdal.Open(geotiff_fn, gdal.GF_Write)
         add_colortable(gtiff, ct)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -117,16 +117,11 @@ setup(
     classifiers=classifiers,
     keywords="",
     url="http://www.ssec.wisc.edu/software/polar2grid/",
-    packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
+    packages=find_packages(),
     include_package_data=True,
     package_data={
         "polar2grid": [
-            "compositors/*.ini",
-            "awips/*.ini",
-            "awips/*.yaml",
             "grids/*.conf",
-            "ninjo/*.ini",
-            "core/rescale_configs/*.ini",
         ]
     },
     # The location of where these are installed are important for the swbundle and glue scripts!

--- a/swbundle/add_coastlines.sh
+++ b/swbundle/add_coastlines.sh
@@ -36,4 +36,4 @@ export POLAR2GRID_HOME="$( cd -P "$( dirname "$SOURCE" )" && cd .. && pwd )"
 # __SWBUNDLE_ENVIRONMENT_INJECTION__
 
 # Call the python module to do the processing, passing all arguments
-${P2G_SHELLB3_DIR}/bin/python -m polar2grid.add_coastlines "$@"
+python3 -m polar2grid.add_coastlines "$@"

--- a/swbundle/add_colormap.sh
+++ b/swbundle/add_colormap.sh
@@ -36,4 +36,4 @@ export POLAR2GRID_HOME="$( cd -P "$( dirname "$SOURCE" )" && cd .. && pwd )"
 # __SWBUNDLE_ENVIRONMENT_INJECTION__
 
 # Call the python module to do the processing, passing all arguments
-${P2G_SHELLB3_DIR}/bin/python -m polar2grid.add_colormap "$@"
+python3 -m polar2grid.add_colormap "$@"

--- a/swbundle/example_enhancements/amsr2_png/enhancements/generic.yaml
+++ b/swbundle/example_enhancements/amsr2_png/enhancements/generic.yaml
@@ -1,0 +1,49 @@
+enhancements:
+  amsr2_btemp_36.5v:
+    name: btemp_36.5v
+    sensor: amsr2
+    standard_name: toa_brightness_temperature
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180.0, max_stretch: 280.0}
+  amsr2_btemp_36.5h:
+    name: btemp_36.5h
+    sensor: amsr2
+    standard_name: toa_brightness_temperature
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180.0, max_stretch: 280.0}
+  amsr2_btemp_89.0av:
+    name: btemp_89.0av
+    sensor: amsr2
+    standard_name: toa_brightness_temperature
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180.0, max_stretch: 280.0}
+  amsr2_btemp_89.0ah:
+    name: btemp_89.0ah
+    sensor: amsr2
+    standard_name: toa_brightness_temperature
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180.0, max_stretch: 280.0}
+  amsr2_btemp_89.0bv:
+    name: btemp_89.0bv
+    sensor: amsr2
+    standard_name: toa_brightness_temperature
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180.0, max_stretch: 280.0}
+  amsr2_btemp_89.0bh:
+    name: btemp_89.0bh
+    sensor: amsr2
+    standard_name: toa_brightness_temperature
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 180.0, max_stretch: 280.0}


### PR DESCRIPTION
Currently it is only possible to have per-run config changes if the user manually changes the directory built into the polar2grid bundle (etc). This new `--extra-config-path` flag lets you specify one or more additional paths (can be specified more than once) with Satpy YAML configuration files.

This PR includes updating the AMSR2 example which used --rescale-configs so it now uses this new flag with a new enhancement configuration file.