### PR TITLE
Backport pyresample fix for bbox lonlats being clockwise

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
   - freetype
   - gdal
   - h5py
+  - matplotlib
   - netcdf4
   - pillow
   - pycoast

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -150,7 +150,7 @@ apidoc_separate_modules = True
 apidoc_extra_args = ["-P"]
 
 # Autodoc
-autodoc_mock_imports = ["matplotlib"]
+autodoc_mock_imports = []
 
 numfig = True
 

--- a/jenkins_environment.yml
+++ b/jenkins_environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - sphinx
   - pytest
   - pytest-lazy-fixture
+  - matplotlib
   - pip:
     - graphviz
     - sphinx-argparse


### PR DESCRIPTION
This causes issues when trying to compute polygon intersections in grid coverage filtering.

See https://github.com/pytroll/pyresample/pull/389