### PR TITLE
Add missing --dnb-saturation-correction flag to viirs_sdr reader

### DIFF
--- a/etc/composites/viirs.yaml
+++ b/etc/composites/viirs.yaml
@@ -297,3 +297,24 @@ composites:
     - I05
     - I04
     standard_name: temperature_difference
+
+  dynamic_dnb:
+    compositor: !!python/name:satpy.composites.viirs.ERFDNB
+    prerequisites:
+      - DNB
+      - dnb_solar_zenith_angle
+      - dnb_lunar_zenith_angle
+      - dnb_moon_illumination_fraction
+    standard_name: equalized_radiance
+    units: "1"
+
+  dynamic_dnb_saturation:
+    compositor: !!python/name:satpy.composites.viirs.ERFDNB
+    prerequisites:
+      - DNB
+      - dnb_solar_zenith_angle
+      - dnb_lunar_zenith_angle
+      - dnb_moon_illumination_fraction
+    standard_name: equalized_radiance
+    units: "1"
+    saturation_correction: true


### PR DESCRIPTION
This was a flag in P2G 2.3, but I had missed it here. It really doesn't fit into how Satpy wants composites to work so what I've done is kind of hacky but it seems to work. Basically there are two versions of the dynamic_dnb composite (the other is `dynamic_dnb_saturation`) and when you specify the `--dnb-saturation-correction` flag the P2G code sees this and swaps the "alias" so `dynamic_dnb` points to `dynamic_dnb_saturation` but still gets called the same thing.