### PR TITLE
Fix warning produced by --dnb-saturation-correction flag

### DIFF
--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -856,10 +856,10 @@ def main(argv=sys.argv[1:]):
         _print_list_products(reader_info, p2g_only=not args.list_products_all)
         return 0
 
-    load_args["products"] = reader_info.get_satpy_products_to_load()
-    if not load_args["products"]:
+    load_args.pop("products")
+    products = reader_info.get_satpy_products_to_load()
+    if not products:
         return -1
-    products = load_args.pop("products")
     scn.load(products, **load_args)
 
     filter_kwargs = {

--- a/polar2grid/readers/viirs_sdr.py
+++ b/polar2grid/readers/viirs_sdr.py
@@ -313,15 +313,15 @@ class ReaderProxy(ReaderProxyBase):
     is_polar2grid_reader = True
 
     def __init__(self, scn: Scene, user_products: list[str]):
-        self.scn = scn
         self._modified_aliases = PRODUCT_ALIASES.copy()
         if "dynamic_dnb_saturation" in user_products:
             # they specified --dnb-saturation-correction
             # let's modify the aliases so dynamic_dnb points to this product
             user_products.remove("dynamic_dnb_saturation")
-            user_products.append("dynamic_dnb")
+            if "dynamic_dnb" not in user_products:
+                user_products.append("dynamic_dnb")
             self._modified_aliases["dynamic_dnb"] = DataQuery(name="dynamic_dnb_saturation")
-        self._orig_user_products = user_products
+        super().__init__(scn, user_products)
 
     def get_default_products(self) -> list[str]:
         """Get products to load if users hasn't specified any others."""

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -97,7 +97,12 @@ class AliasHandler:
     ):
 
         self._all_aliases = all_aliases
-        self._user_products = user_products
+        self._user_products = self._unique_ordered_list(user_products)
+
+    @staticmethod
+    def _unique_ordered_list(orig_list):
+        seen = set()
+        return [item for item in orig_list if not (item in seen or seen.add(item))]
 
     def remove_unknown_user_products(
         self,
@@ -167,7 +172,6 @@ class AliasHandler:
 
             if matching_satpy_id in satpy_id_to_p2g_name:
                 logger.warning("Multiple product names map to the same identifier in Satpy")
-                print(matching_satpy_id, satpy_id_to_p2g_name[matching_satpy_id], p2g_name)
             satpy_id_to_p2g_name[matching_satpy_id] = p2g_name
 
         for satpy_product in satpy_products:


### PR DESCRIPTION
Closes #420

Currently this only implements the fix for the warning message. Summary of the problem is that the flag was causing the list of products to load to be `["dynamic_dnb", "dynamic_dnb"]` and then when P2G was looking up what name this might refer to in Satpy-land it was seeing it already had something looked up. Simple fix, but I made it in two places to be sure.

I still need to look into the black images.