### PR TITLE
Optimize grid coverage checks and avoid checks with certain dynamic grids

### DIFF
--- a/polar2grid/filters/_base.py
+++ b/polar2grid/filters/_base.py
@@ -81,7 +81,7 @@ class BaseFilter:
         _cache = {}
         remaining_ids = []
         filtered_ids = []
-        for data_id in scene.keys():
+        for data_id in self._iter_scene_coarsest_to_finest_area(scene):
             logger.debug("Analyzing '{}' for filtering...".format(data_id))
             if not self._filter_data_array(scene[data_id], _cache):
                 remaining_ids.append(data_id)
@@ -93,3 +93,10 @@ class BaseFilter:
         new_scn = scene.copy(remaining_ids)
         new_scn._wishlist = scene.wishlist.copy()
         return new_scn
+
+    @staticmethod
+    def _iter_scene_coarsest_to_finest_area(scene: Scene):
+        by_area_list = list(scene.iter_by_area())
+        by_area_list = sorted(by_area_list, key=lambda x: x[0].shape[0])
+        for _, data_arrays in by_area_list:
+            yield from data_arrays

--- a/polar2grid/filters/resample_coverage.py
+++ b/polar2grid/filters/resample_coverage.py
@@ -82,16 +82,14 @@ class ResampleCoverageFilter(BaseFilter):
         """
         if not self._matches_criteria(data_arr):
             return False
-
         source_area = data_arr.attrs.get("area")
         if source_area is None:
             return False
-
         if source_area.ndim == 1:
             logger.debug("Source data is 1 dimensional, will not filter based on resampling coverage.")
             return False
-        source_polygon = polygon_for_area(source_area)
-        coverage_fraction = _get_intersection_coverage(source_polygon, self._target_polygon)
+
+        coverage_fraction = self._get_and_cache_coverage_fraction(data_arr, source_area, _cache)
         if coverage_fraction >= self._coverage_fraction:
             logger.debug("Resampling found %f%% coverage.", coverage_fraction * 100)
             return False
@@ -101,3 +99,20 @@ class ResampleCoverageFilter(BaseFilter):
             data_arr.attrs["name"],
         )
         return True
+
+    def _get_and_cache_coverage_fraction(self, source_data: DataArray, source_area: PRGeometry, cache: dict) -> float:
+        platform_name = source_data.attrs.get("platform_name")
+        sensor_name = source_data.attrs.get("sensor")
+        key = (platform_name, sensor_name)
+        if key in cache:
+            logger.debug(f"Reusing cache coverage fraction for {key}")
+            return cache[key]
+
+        logger.debug(f"Computing coverage fraction for {key}")
+        source_polygon = polygon_for_area(source_area)
+        coverage_fraction = _get_intersection_coverage(source_polygon, self._target_polygon)
+        if platform_name is None or sensor_name is None:
+            logger.debug("Platform and sensor metadata missing from data. Won't cache coverage information.")
+            return coverage_fraction
+        cache[key] = coverage_fraction
+        return coverage_fraction

--- a/polar2grid/filters/resample_coverage.py
+++ b/polar2grid/filters/resample_coverage.py
@@ -103,6 +103,8 @@ class ResampleCoverageFilter(BaseFilter):
     def _get_and_cache_coverage_fraction(self, source_data: DataArray, source_area: PRGeometry, cache: dict) -> float:
         platform_name = source_data.attrs.get("platform_name")
         sensor_name = source_data.attrs.get("sensor")
+        if sensor_name and not isinstance(sensor_name, str):
+            sensor_name = "-".join(sorted(sensor_name))
         key = (platform_name, sensor_name)
         if key in cache:
             logger.debug(f"Reusing cache coverage fraction for {key}")

--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -140,6 +140,8 @@ def viirs_sdr_i01_data_array(viirs_sdr_i_swath_def) -> xr.DataArray:
             "name": "I01",
             "start_time": START_TIME,
             "end_time": START_TIME,
+            "resolution": 371,
+            "reader": "viirs_sdr",
         },
     )
 
@@ -159,6 +161,8 @@ def abi_l1b_c01_data_array(goes_east_conus_area_def) -> xr.DataArray:
             "observation_type": "Rad",
             "standard_name": "toa_bidirectional_reflectance",
             "scene_abbr": "C",
+            "resolution": 1000,
+            "reader": "abi_l1b",
         },
     )
 

--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -95,6 +95,8 @@ def viirs_sdr_i_swath_def() -> SwathDefinition:
             "sensor": "viirs",
             "start_time": START_TIME,
             "end_time": START_TIME,
+            "resolution": 371,
+            "reader": "viirs_sdr",
         },
     )
     lats_data_arr = xr.DataArray(
@@ -106,6 +108,8 @@ def viirs_sdr_i_swath_def() -> SwathDefinition:
             "sensor": "viirs",
             "start_time": START_TIME,
             "end_time": START_TIME,
+            "resolution": 371,
+            "reader": "viirs_sdr",
         },
     )
     return SwathDefinition(lons_data_arr, lats_data_arr)

--- a/polar2grid/tests/test_resample/test_resample_scene.py
+++ b/polar2grid/tests/test_resample/test_resample_scene.py
@@ -116,6 +116,7 @@ def test_partial_filter(viirs_sdr_i01_scene):
     orig_lons = new_i01.attrs["area"].lons
     orig_lats = new_i01.attrs["area"].lats
     new_lons = orig_lons + 180.0
+    new_lons.attrs = orig_lons.attrs.copy()
     new_swath_def = SwathDefinition(new_lons, orig_lats)
     new_i01.attrs["name"] = "I01_2"
     new_i01.attrs["area"] = new_swath_def

--- a/polar2grid/tests/test_resample/test_resample_scene.py
+++ b/polar2grid/tests/test_resample/test_resample_scene.py
@@ -119,10 +119,13 @@ def test_partial_filter(viirs_sdr_i01_scene):
     new_swath_def = SwathDefinition(new_lons, orig_lats)
     new_i01.attrs["name"] = "I01_2"
     new_i01.attrs["area"] = new_swath_def
+    new_i01.attrs["sensor"] = {"viirs", "modis"}
     new_scn = Scene()
     new_scn["I01"] = viirs_sdr_i01_scene["I01"]
     new_scn["I01_2"] = new_i01
 
+    # computation 1: input swath 1 polygon
+    # computation 3: input swath 2 polygon (filtered and not resampled)
     with dask.config.set(scheduler=CustomScheduler(2)):
         scenes_to_save = resample_scene(
             new_scn,


### PR DESCRIPTION
Closes #423 

This PR includes three major changes as far as code and execution go:

1. Adds a hidden `--create-profile` which when specified creates an HTML document (in the local directory by default) of dask diagnostics plots including a task stream, a CPU/memory resource plot, and a dask cache plot. This is basic information needed to identify major performance issues in the execution of the main glue script.
2. Refactors the filtering logic so that coarser resolution grids are processed first. Using this I also made the grid coverage calculations cache results based on (platform name, sensor name). This means that the coarsest resolution area/grid of a single execution is checked for resampling coverage first and then that percentage of coverage is used for all other bands. This assumes that a single execution of Polar2Grid and Geo2Grid will only have one time step/orbit of data for a single sensor. I can't think of a time when this isn't true.
3. Refactors when grid coverage calculations are done so that it doesn't happen if the grid has dynamically generated extents. This is a nice optimization, but also gets around the issues I've been having where pyresample's current spherical polygon calculations have trouble with two polygons that have very small overlapping regions (like an area generated based on the bounds of a swath).