### PR TITLE
Add command line option to mask saturated modis_l1b band 2 pixels

### DIFF
--- a/etc/enhancements/modis.yaml
+++ b/etc/enhancements/modis.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  pre_enhanced_modis_crefl:
+    sensor: modis
+    standard_name: preenhanced_crefl
+    operations: []

--- a/polar2grid/readers/modis_l1b.py
+++ b/polar2grid/readers/modis_l1b.py
@@ -135,7 +135,7 @@ from typing import Optional
 
 from satpy import DataQuery
 
-from polar2grid.core.script_utils import ExtendConstAction
+from polar2grid.core.script_utils import BooleanOptionalAction, ExtendConstAction
 
 from ._base import ReaderProxyBase
 
@@ -249,5 +249,11 @@ def add_reader_argument_groups(
         action=ExtendConstAction,
         const=_AWIPS_FALSE_COLOR,
         help="Add individual CREFL corrected products to create " "the 'false_color' composite in AWIPS.",
+    )
+    group.add_argument(
+        "--mask-saturated",
+        default=False,
+        action=BooleanOptionalAction,
+        help="Mask saturated band 2 pixels as invalid instead of clipping to max reflectance",
     )
     return group, None

--- a/polar2grid/readers/modis_l1b.py
+++ b/polar2grid/readers/modis_l1b.py
@@ -130,12 +130,13 @@ angle is less than 90 degrees.
 """
 from __future__ import annotations
 
+import argparse
 from argparse import ArgumentParser, _ArgumentGroup
 from typing import Optional
 
 from satpy import DataQuery
 
-from polar2grid.core.script_utils import BooleanOptionalAction, ExtendConstAction
+from polar2grid.core.script_utils import ExtendConstAction
 
 from ._base import ReaderProxyBase
 
@@ -253,7 +254,8 @@ def add_reader_argument_groups(
     group.add_argument(
         "--mask-saturated",
         default=False,
-        action=BooleanOptionalAction,
-        help="Mask saturated band 2 pixels as invalid instead of clipping to max reflectance",
+        action="store_true",
+        help=argparse.SUPPRESS,
+        # help="Mask saturated band 2 pixels as invalid instead of clipping to max reflectance",
     )
     return group, None


### PR DESCRIPTION
This has to be in the command line so it automatically gets passed to Satpy to turn off masking of saturated pixels. Closes the saturated portion of #422. I will try to find a pretty way to hide it.