### PR TITLE
Fix seadas_l2 and acspo resampling defaults not being instrument-specific

### DIFF
--- a/build_environment.yml
+++ b/build_environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - conda-pack
   - configobj
   - curl
-  - dask>=2021.11.2
+  - dask>=2022.3.0
   - distributed
   - ffmpeg
   - fontconfig
@@ -24,9 +24,9 @@ dependencies:
   - pykdtree
   - pyorbital>=1.7.1
   - pyproj>=3.1.0
-  - pyresample>=1.22.3
+  - pyresample>=1.23.0
   - pyshp
-  - pyspectral>=0.10.6
+  - pyspectral>=0.11.0
   - python=3.10
   - python-geotiepoints>=1.4.0
   - pyyaml
@@ -38,7 +38,7 @@ dependencies:
   - trollsift>=0.4.0
   - scipy
   - zarr
-  - xarray>=0.20.1
+  - xarray>=2022.3.0
   - fsspec
   - s3fs
   - pip:

--- a/etc/resampling.yaml
+++ b/etc/resampling.yaml
@@ -59,13 +59,21 @@ resampling:
     kwargs:
       weight_delta_max: 10.0
       weight_distance_max: 1.0
-  default_seadas_l2:
+  default_seadas_l2_viirs:
     area_type: swath
     sensor: viirs
     reader: seadas_l2
     resampler: ewa
     kwargs:
       weight_delta_max: 40.0
+      weight_distance_max: 2.0
+  default_seadas_l2_modis:
+    area_type: swath
+    sensor: modis
+    reader: seadas_l2
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 10.0
       weight_distance_max: 2.0
   default_avhrr:
     area_type: swath
@@ -188,7 +196,24 @@ resampling:
   default_acspo_sst_viirs:
     area_type: swath
     name: sst
+    sensor: viirs
     resampler: ewa
     kwargs:
       weight_delta_max: 40.0
+      weight_distance_max: 2.0
+  default_acspo_sst_modis:
+    area_type: swath
+    name: sst
+    sensor: modis
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 10.0
+      weight_distance_max: 1.0
+  default_acspo_sst_avhrr:
+    area_type: swath
+    name: sst
+    sensor: avhrr
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 10.0
       weight_distance_max: 1.0


### PR DESCRIPTION
While debugging other issues related to resampling, @kathys and I noticed that the default resampling configuration for ACSPO SST and seadas_l2 products were not specific to the instruments. All bands were being resampled using VIIRS weighting when MODIS (or AVHRR) have different settings. This PR adds those missing configuration settings.