### PR TITLE
Fix --dnb-saturation-correction flag clearing default product list

### DIFF
--- a/polar2grid/enhancements/shared.py
+++ b/polar2grid/enhancements/shared.py
@@ -40,9 +40,9 @@ def temperature_difference(img, min_stretch, max_stretch, **kwargs):
     # we assume uint8 images for legacy AWIPS comparisons
     offset = 1 / 255.0
     factor = (205.0 - 5.0) / 255.0
-    img.data = img.data * factor
+    img.data.data = img.data.data * factor
     img.data.data = np.clip(img.data.data, -offset, factor + offset)  # 4 and 206 offset
-    img.data = img.data + 5 * offset  # lower bound of 5
+    img.data.data = img.data.data + 5 * offset  # lower bound of 5
     return img
 
 

--- a/polar2grid/readers/viirs_sdr.py
+++ b/polar2grid/readers/viirs_sdr.py
@@ -318,8 +318,6 @@ class ReaderProxy(ReaderProxyBase):
             # they specified --dnb-saturation-correction
             # let's modify the aliases so dynamic_dnb points to this product
             user_products.remove("dynamic_dnb_saturation")
-            if "dynamic_dnb" not in user_products:
-                user_products.append("dynamic_dnb")
             self._modified_aliases["dynamic_dnb"] = DataQuery(name="dynamic_dnb_saturation")
         super().__init__(scn, user_products)
 

--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -545,11 +545,11 @@ def full_viirs_data_array_dict(
         data_arrays[data_id] = viirs_sdr_i01_data_array.copy()
     for data_id in VIIRS_I_IDS[3:]:
         data_arrays[data_id] = viirs_sdr_i04_data_array.copy()
-    for data_id in VIIRS_M_IDS[:12] + VIIRS_M_ANGLES_IDS:
+    for data_id in VIIRS_M_IDS[:12]:
         data_arrays[data_id] = viirs_sdr_m01_data_array.copy()
     for data_id in VIIRS_M_IDS[12:]:
         data_arrays[data_id] = viirs_sdr_m12_data_array.copy()
-    for data_id in VIIRS_DNB_IDS + VIIRS_DNB_ANGLES_IDS:
+    for data_id in VIIRS_DNB_IDS:
         data_arrays[data_id] = viirs_sdr_dnb_data_array.copy()
 
     all_angle_arrays = [viirs_sdr_i01_data_array, viirs_sdr_m01_data_array, viirs_sdr_dnb_data_array]
@@ -573,17 +573,22 @@ def viirs_sdr_full_scene(full_viirs_data_array_dict) -> Scene:
         all_dataset_ids=VIIRS_ALL_IDS,
         available_dataset_ids=list(data_arrays.keys()),
     )
-    # remove angles and other ancillary datasets that shouldn't be in the wishlist
-    # scn._wishlist.clear()
-    # for angle_data_id in VIIRS_M_ANGLES_IDS + VIIRS_I_ANGLES_IDS + VIIRS_DNB_ANGLES_IDS:
-    #     scn._wishlist.remove(angle_data_id)
     return scn
 
 
 @pytest.fixture
 def abi_l1b_c01_scene(abi_l1b_c01_data_array) -> Scene:
-    scn = Scene()
-    scn["C01"] = abi_l1b_c01_data_array
+    c01_id = make_dataid(name="C01", calibration="reflectance", resolution=1000)
+    data_arrays = {
+        c01_id: abi_l1b_c01_data_array,
+    }
+    scn = _TestingScene(
+        reader="abi_l1b",
+        filenames=["/fake/filename"],
+        data_array_dict=data_arrays,
+        all_dataset_ids=[c01_id],
+        available_dataset_ids=[c01_id],
+    )
     return scn
 
 

--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -33,10 +33,14 @@ import pytest
 import xarray as xr
 from numpy.typing import DTypeLike, NDArray
 from pyresample.geometry import AreaDefinition, SwathDefinition
-from satpy import Scene
+from satpy import DatasetDict, Scene
+from satpy.readers.yaml_reader import FileYAMLReader
+from satpy.tests.utils import make_dataid
 
 PKG_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 VIIRS_I_CHUNKS = (32 * 3, 6400)
+VIIRS_M_CHUNKS = (16 * 3, 3200)
+VIIRS_DNB_CHUNKS = (16 * 3, 4064)
 START_TIME = datetime(2021, 1, 1, 12, 0, 0)
 
 
@@ -57,6 +61,68 @@ def chtmpdir(tmp_path: Path):
         yield tmp_path
     finally:
         os.chdir(lwd)
+
+
+class _FakeReader(FileYAMLReader):
+    """Fake reader to avoid loading real files during testing."""
+
+    def __init__(self, reader_name, dataset_dict, all_dataset_ids, available_dataset_ids):
+        self._name = reader_name
+        self._forced_all_ids = all_dataset_ids
+        self._forced_available_ids = available_dataset_ids
+        self._forced_products = DatasetDict(dataset_dict)
+
+    @property
+    def start_time(self):
+        return START_TIME
+
+    @property
+    def end_time(self):
+        return START_TIME
+
+    @property
+    def sensor_names(self):
+        return {
+            "viirs_sdr": {"viirs"},
+            "abi_l1b": {"abi"},
+        }[self._name]
+
+    @property
+    def all_dataset_ids(self):
+        return self._forced_all_ids
+
+    @property
+    def available_dataset_ids(self):
+        return self._forced_available_ids
+
+    def load(self, dataset_keys, previous_datasets=None, **kwargs):
+        new_result = DatasetDict()
+        for data_query in dataset_keys:
+            try:
+                data_arr = self._forced_products[data_query]
+            except KeyError:
+                continue
+            data_arr.attrs.update(data_query.to_dict())
+            new_result[data_query] = data_arr
+        return new_result
+
+
+class _TestingScene(Scene):
+    """Special Scene class to mimic a real Scene that would be created during normal execution."""
+
+    def __init__(self, *args, data_array_dict=None, all_dataset_ids=None, available_dataset_ids=None, **kwargs):
+        self._forced_all_ids = all_dataset_ids
+        self._forced_available_ids = available_dataset_ids
+        self._forced_products = data_array_dict
+
+        super().__init__(*args, **kwargs)
+
+    def _create_reader_instances(self, filenames=None, reader=None, reader_kwargs=None):
+        if reader is None or filenames is None or self._forced_all_ids is None or self._forced_available_ids is None:
+            return {}
+        return {
+            reader: _FakeReader(reader, self._forced_products, self._forced_all_ids, self._forced_available_ids),
+        }
 
 
 # Config Files #
@@ -116,6 +182,70 @@ def viirs_sdr_i_swath_def() -> SwathDefinition:
 
 
 @pytest.fixture(scope="session")
+def viirs_sdr_m_swath_def() -> SwathDefinition:
+    lons, lats = _generate_lonlat_data((768, 3200))
+    lons_data_arr = xr.DataArray(
+        da.from_array(lons, chunks=VIIRS_M_CHUNKS),
+        dims=("y", "x"),
+        attrs={
+            "rows_per_scan": 16,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 742,
+            "reader": "viirs_sdr",
+        },
+    )
+    lats_data_arr = xr.DataArray(
+        da.from_array(lats, chunks=VIIRS_M_CHUNKS),
+        dims=("y", "x"),
+        attrs={
+            "rows_per_scan": 16,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 742,
+            "reader": "viirs_sdr",
+        },
+    )
+    return SwathDefinition(lons_data_arr, lats_data_arr)
+
+
+@pytest.fixture(scope="session")
+def viirs_sdr_dnb_swath_def() -> SwathDefinition:
+    lons, lats = _generate_lonlat_data((768, 4064))
+    lons_data_arr = xr.DataArray(
+        da.from_array(lons, chunks=VIIRS_DNB_CHUNKS),
+        dims=("y", "x"),
+        attrs={
+            "rows_per_scan": 16,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 743,
+            "reader": "viirs_sdr",
+        },
+    )
+    lats_data_arr = xr.DataArray(
+        da.from_array(lats, chunks=VIIRS_DNB_CHUNKS),
+        dims=("y", "x"),
+        attrs={
+            "rows_per_scan": 16,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 743,
+            "reader": "viirs_sdr",
+        },
+    )
+    return SwathDefinition(lons_data_arr, lats_data_arr)
+
+
+@pytest.fixture(scope="session")
 def goes_east_conus_area_def() -> AreaDefinition:
     return AreaDefinition(
         "goes_east",
@@ -146,6 +276,97 @@ def viirs_sdr_i01_data_array(viirs_sdr_i_swath_def) -> xr.DataArray:
             "end_time": START_TIME,
             "resolution": 371,
             "reader": "viirs_sdr",
+            "calibration": "reflectance",
+            "standard_name": "toa_bidirectional_reflectance",
+            "units": "%",
+        },
+    )
+
+
+@pytest.fixture
+def viirs_sdr_i04_data_array(viirs_sdr_i_swath_def) -> xr.DataArray:
+    return xr.DataArray(
+        da.zeros((1536, 6400), dtype=np.float32),
+        dims=("y", "x"),
+        attrs={
+            "area": viirs_sdr_i_swath_def,
+            "rows_per_scan": 32,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "name": "I04",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 371,
+            "reader": "viirs_sdr",
+            "calibration": "brightness_temperature",
+            "standard_name": "toa_brightness_temperature",
+            "units": "K",
+        },
+    )
+
+
+@pytest.fixture
+def viirs_sdr_m01_data_array(viirs_sdr_m_swath_def) -> xr.DataArray:
+    return xr.DataArray(
+        da.zeros((768, 3200), dtype=np.float32),
+        dims=("y", "x"),
+        attrs={
+            "area": viirs_sdr_m_swath_def,
+            "rows_per_scan": 16,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "name": "M01",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 742,
+            "reader": "viirs_sdr",
+            "calibration": "reflectance",
+            "standard_name": "toa_bidirectional_reflectance",
+            "units": "%",
+        },
+    )
+
+
+@pytest.fixture
+def viirs_sdr_m12_data_array(viirs_sdr_m_swath_def) -> xr.DataArray:
+    return xr.DataArray(
+        da.zeros((768, 3200), dtype=np.float32),
+        dims=("y", "x"),
+        attrs={
+            "area": viirs_sdr_m_swath_def,
+            "rows_per_scan": 16,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "name": "M12",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 743,
+            "reader": "viirs_sdr",
+            "calibration": "brightness_temperature",
+            "standard_name": "toa_brightness_temperature",
+            "units": "K",
+        },
+    )
+
+
+@pytest.fixture
+def viirs_sdr_dnb_data_array(viirs_sdr_dnb_swath_def) -> xr.DataArray:
+    return xr.DataArray(
+        da.zeros((768, 4064), dtype=np.float32),
+        dims=("y", "x"),
+        attrs={
+            "area": viirs_sdr_dnb_swath_def,
+            "rows_per_scan": 16,
+            "platform_name": "npp",
+            "sensor": "viirs",
+            "name": "DNB",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 743,
+            "reader": "viirs_sdr",
+            "calibration": "brightness_temperature",
+            "standard_name": "toa_brightness_temperature",
+            "units": "W m-2 sr-1",
         },
     )
 
@@ -193,11 +414,169 @@ def abi_l1b_airmass_data_array(goes_east_conus_area_def) -> xr.DataArray:
 
 # Scenes #
 
+_mods = ("sunz_corrected_iband",)
+VIIRS_I_IDS = [
+    make_dataid(name="I01", wavelength=(0.6, 0.64, 0.68), resolution=371, calibration="reflectance", modifiers=_mods),
+    make_dataid(
+        name="I02", wavelength=(0.845, 0.865, 0.884), resolution=371, calibration="reflectance", modifiers=_mods
+    ),
+    make_dataid(
+        name="I03", wavelength=(1.580, 1.610, 1.640), resolution=371, calibration="reflectance", modifiers=_mods
+    ),
+    make_dataid(name="I04", wavelength=(3.58, 3.74, 3.90), resolution=371, calibration="brightness_temperature"),
+    make_dataid(name="I05", wavelength=(10.5, 11.45, 12.3), resolution=371, calibration="brightness_temperature"),
+]
+VIIRS_M_IDS = []
+_mods = ("sunz_corrected",)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M01", wavelength=(0.402, 0.412, 0.422), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M02", wavelength=(0.436, 0.445, 0.454), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M03", wavelength=(0.478, 0.488, 0.498), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M04", wavelength=(0.545, 0.555, 0.565), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M05", wavelength=(0.662, 0.672, 0.682), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M06", wavelength=(0.739, 0.746, 0.754), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M07", wavelength=(0.846, 0.865, 0.885), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M08", wavelength=(1.23, 1.24, 1.25), resolution=742, calibration="reflectance", modifiers=_mods)
+)
+VIIRS_M_IDS.append(
+    make_dataid(
+        name="M09", wavelength=(1.371, 1.378, 1.386), resolution=742, calibration="reflectance", modifiers=_mods
+    )
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M10", wavelength=(1.58, 1.61, 1.64), resolution=742, calibration="reflectance", modifiers=_mods)
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M11", wavelength=(2.225, 2.25, 2.275), resolution=742, calibration="reflectance", modifiers=_mods)
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M12", wavelength=(3.61, 3.7, 3.79), resolution=742, calibration="brightness_temperature")
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M13", wavelength=(3.973, 4.05, 4.128), resolution=742, calibration="brightness_temperature")
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M14", wavelength=(8.4, 8.55, 8.7), resolution=742, calibration="brightness_temperature")
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M15", wavelength=(10.263, 10.763, 11.263), resolution=742, calibration="brightness_temperature")
+)
+VIIRS_M_IDS.append(
+    make_dataid(name="M16", wavelength=(11.538, 12.013, 12.489), resolution=742, calibration="brightness_temperature")
+)
+VIIRS_DNB_IDS = [make_dataid(name="DNB", resolution=743, calibration="radiance")]
+VIIRS_M_ANGLES_IDS = []
+VIIRS_I_ANGLES_IDS = []
+VIIRS_DNB_ANGLES_IDS = []
+for angle_suffix in ["solar_zenith_angle", "solar_azimuth_angle", "satellite_zenith_angle", "satellite_azimuth_angle"]:
+    VIIRS_M_ANGLES_IDS.append(make_dataid(name=angle_suffix, resolution=742))
+    VIIRS_I_ANGLES_IDS.append(make_dataid(name=angle_suffix, resolution=371))
+    VIIRS_DNB_ANGLES_IDS.append(make_dataid(name="dnb_" + angle_suffix, resolution=743))
+VIIRS_DNB_ANGLES_IDS.append(make_dataid(name="dnb_lunar_zenith_angle", resolution=743))
+VIIRS_DNB_ANGLES_IDS.append(make_dataid(name="dnb_lunar_azimuth_angle", resolution=743))
+VIIRS_DNB_ANGLES_IDS.append(make_dataid(name="dnb_moon_illumination_fraction"))
+
+# VIIRS_COMP_IDS = [
+#     make_dataid(name="dynamic_dnb"),
+#     make_dataid(name="histogram_dnb"),
+#     make_dataid(name="adaptive_dnb"),
+#     make_dataid(name="hncc_dnb"),
+#     make_dataid(name="ifog"),
+#     make_dataid(name="true_color"),
+#     make_dataid(name="false_color"),
+# ]
+VIIRS_ALL_IDS = (
+    VIIRS_I_IDS + VIIRS_M_IDS + VIIRS_DNB_IDS + VIIRS_M_ANGLES_IDS + VIIRS_I_ANGLES_IDS + VIIRS_DNB_ANGLES_IDS
+)
+
 
 @pytest.fixture
 def viirs_sdr_i01_scene(viirs_sdr_i01_data_array) -> Scene:
-    scn = Scene()
-    scn["I01"] = viirs_sdr_i01_data_array
+    scn = _TestingScene(
+        reader="viirs_sdr",
+        filenames=["/fake/filename"],
+        data_array_dict={
+            VIIRS_I_IDS[0]: viirs_sdr_i01_data_array.copy(),
+        },
+        all_dataset_ids=VIIRS_ALL_IDS,
+        available_dataset_ids=VIIRS_I_IDS[:1],
+    )
+    return scn
+
+
+@pytest.fixture
+def full_viirs_data_array_dict(
+    viirs_sdr_i01_data_array,
+    viirs_sdr_i04_data_array,
+    viirs_sdr_m01_data_array,
+    viirs_sdr_m12_data_array,
+    viirs_sdr_dnb_data_array,
+):
+    data_arrays = {}
+    for data_id in VIIRS_I_IDS[:3]:
+        data_arrays[data_id] = viirs_sdr_i01_data_array.copy()
+    for data_id in VIIRS_I_IDS[3:]:
+        data_arrays[data_id] = viirs_sdr_i04_data_array.copy()
+    for data_id in VIIRS_M_IDS[:12] + VIIRS_M_ANGLES_IDS:
+        data_arrays[data_id] = viirs_sdr_m01_data_array.copy()
+    for data_id in VIIRS_M_IDS[12:]:
+        data_arrays[data_id] = viirs_sdr_m12_data_array.copy()
+    for data_id in VIIRS_DNB_IDS + VIIRS_DNB_ANGLES_IDS:
+        data_arrays[data_id] = viirs_sdr_dnb_data_array.copy()
+
+    all_angle_arrays = [viirs_sdr_i01_data_array, viirs_sdr_m01_data_array, viirs_sdr_dnb_data_array]
+    all_angle_ids = [VIIRS_I_ANGLES_IDS, VIIRS_M_ANGLES_IDS, VIIRS_DNB_ANGLES_IDS]
+    for base_data_arr, angle_ids in zip(all_angle_arrays, all_angle_ids):
+        for angle_id in angle_ids:
+            data_arr = base_data_arr.copy()
+            del data_arr.attrs["calibration"]
+            data_arr.attrs["name"] = angle_id["name"]
+            data_arrays[angle_id] = data_arr
+    return data_arrays
+
+
+@pytest.fixture
+def viirs_sdr_full_scene(full_viirs_data_array_dict) -> Scene:
+    data_arrays = full_viirs_data_array_dict
+    scn = _TestingScene(
+        reader="viirs_sdr",
+        filenames=["/fake/filename"],
+        data_array_dict=data_arrays,
+        all_dataset_ids=VIIRS_ALL_IDS,
+        available_dataset_ids=list(data_arrays.keys()),
+    )
+    # remove angles and other ancillary datasets that shouldn't be in the wishlist
+    # scn._wishlist.clear()
+    # for angle_data_id in VIIRS_M_ANGLES_IDS + VIIRS_I_ANGLES_IDS + VIIRS_DNB_ANGLES_IDS:
+    #     scn._wishlist.remove(angle_data_id)
     return scn
 
 

--- a/polar2grid/tests/test_enhancements.py
+++ b/polar2grid/tests/test_enhancements.py
@@ -64,17 +64,18 @@ class TestP2GEnhancements:
         """Reset Satpy config path back to the original value."""
         satpy.config.set(config_path=self._old_path)
 
-    def test_temperature_difference(self, tmpdir, abi_l1b_c01_data_array):
+    def test_temperature_difference(self, tmp_path, abi_l1b_c01_data_array):
         new_data_arr = abi_l1b_c01_data_array.copy()
         data = da.linspace(-10, 10, new_data_arr.size).reshape(new_data_arr.shape)
         new_data_arr.data = data
         new_data_arr.attrs["name"] = "test_temperature_difference"
         scn = Scene()
         scn["test_temperature_difference"] = new_data_arr
-        out_fn = str(tmpdir + "test_temperature_difference.tif")
-        scn.save_datasets(filename=out_fn)
+        scn.save_datasets(filename="{name}_{standard_name}.tif", base_dir=str(tmp_path))
 
-        with rasterio.open(out_fn, "r") as out_ds:
+        exp_fn = tmp_path / "test_temperature_difference_toa_bidirectional_reflectance.tif"
+        assert os.path.isfile(exp_fn)
+        with rasterio.open(exp_fn, "r") as out_ds:
             assert out_ds.count == 2
             l_data = out_ds.read(1)
             # see polar2grid/tests/etc/enhancements/generic.yaml

--- a/polar2grid/tests/test_resample/test_resample_scene.py
+++ b/polar2grid/tests/test_resample/test_resample_scene.py
@@ -92,6 +92,7 @@ def test_resample_single_result_per_grid(
     is_polar2grid,
 ):
     with dask.config.set(scheduler=CustomScheduler(max_computes)):
+        input_scene.load(exp_names)
         scenes_to_save = resample_scene(
             input_scene,
             grids,
@@ -108,11 +109,11 @@ def test_resample_single_result_per_grid(
             assert exp_name in id_names
 
 
-def test_partial_filter(viirs_sdr_i01_scene):
+def test_partial_filter(viirs_sdr_i01_data_array):
     """Test that resampling completes even when coverage filters some datasets."""
     # make another DataArray that is shifted away from the target area
     # orig_lons, orig_lats = viirs_sdr_i01_scene['I01'].attrs['area'].get_lonlats()
-    new_i01 = viirs_sdr_i01_scene["I01"].copy()
+    new_i01 = viirs_sdr_i01_data_array.copy()
     orig_lons = new_i01.attrs["area"].lons
     orig_lats = new_i01.attrs["area"].lats
     new_lons = orig_lons + 180.0
@@ -122,7 +123,7 @@ def test_partial_filter(viirs_sdr_i01_scene):
     new_i01.attrs["area"] = new_swath_def
     new_i01.attrs["sensor"] = {"viirs", "modis"}
     new_scn = Scene()
-    new_scn["I01"] = viirs_sdr_i01_scene["I01"]
+    new_scn["I01"] = viirs_sdr_i01_data_array
     new_scn["I01_2"] = new_i01
 
     # computation 1: input swath 1 polygon

--- a/polar2grid/tests/test_writers/test_hdf5.py
+++ b/polar2grid/tests/test_writers/test_hdf5.py
@@ -50,6 +50,7 @@ class TestHDF5Writer:
         """Test basic writing of gridded data."""
         import h5py
 
+        abi_l1b_c01_scene.load(["C01"])
         abi_l1b_c01_scene.save_datasets(
             writer="hdf5",
             base_dir=str(tmp_path),


### PR DESCRIPTION
Includes fixes to the `temperature_difference` enhancement which Closes #427

This PR updates the VIIRS reader so it doesn't accidentally clear the default product list so only dynamic_dnb is created. The fix itself is rather small, but as part of this I added much more complex tests which should allow for better testing of VIIRS related functionality in the future. Closes #441 