### PR TITLE
Change resampling arguments to always start with configurated defaults

### DIFF
--- a/polar2grid/tests/test_resample/test_resample_scene.py
+++ b/polar2grid/tests/test_resample/test_resample_scene.py
@@ -95,7 +95,7 @@ from polar2grid.resample._resample_scene import resample_scene
             True,
             DaskEWAResampler,
             {"weight_distance_max": 3.0, "maximum_weight_mode": True},
-            {"weight_distance_max": 3.0, "maximum_weight_mode": True},
+            {"weight_delta_max": 40.0, "weight_distance_max": 3.0, "maximum_weight_mode": True},
         ),
         (
             lazy_fixture("viirs_sdr_i01_scene"),


### PR DESCRIPTION
As discussed in a meeting today, we decided that the configured values in `resampling.yaml` should *always* be consulted regardless of if `--method <resampling method>` is provided or not. This means the general workflow for determining arguments for resampling is:

1. Get configured resampling default method, arguments, and default target.
2. Override and update method and options based on user command line arguments
3. If default target grid is None (no `-g` from user) then use "MAX" if resampling method was not configured or is "native", otherwise "wgs84_fit" if we're running Polar2Grid or "MAX" if Geo2Grid.
4. Right before resampling, if resampling method hasn't been specified or configured, we use "native" if it is a native grid, or "nearest" otherwise.