### PR TITLE
Fix AVHRR reader using "avhrr-3" name instead of "avhrr"

### DIFF
--- a/doc/source/readers/avhrr.rst
+++ b/doc/source/readers/avhrr.rst
@@ -10,7 +10,7 @@ Command Line Arguments
 .. argparse::
     :module: polar2grid.readers.avhrr_l1b_aapp
     :func: add_reader_argument_groups
-    :prog: polar2grid.sh -r avhrr -w <writer>
+    :prog: polar2grid.sh -r avhrr_l1b_aapp -w <writer>
     :passparser:
 
 Execution Examples
@@ -18,16 +18,16 @@ Execution Examples
 
 .. code-block:: bash
 
-    polar2grid.sh -r avhrr -w awips_tiled --list-products -f /l1b/hrpt_noaa18_20170202_2242_60321.l1b
+    polar2grid.sh -r avhrr_l1b_aapp -w awips_tiled --list-products -f /l1b/hrpt_noaa18_20170202_2242_60321.l1b
 
-    polar2grid.sh avhrr gtiff -f ../input/hrpt_M01_20170202_0227_22708.l1b
+    polar2grid.sh -r avhrr -w geotiff -f ../input/hrpt_M01_20170202_0227_22708.l1b
 
-    polar2grid.sh avhrr gtiff -p band1_vis band4_bt -f /data/hrpt_noaa19_20170202_2042_41144.l1b
+    polar2grid.sh -r avhrr -w geotiff -p band1_vis band4_bt -f /data/hrpt_noaa19_20170202_2042_41144.l1b
 
-    polar2grid.sh avhrr awips_tiled -p band3a_vis -g lcc_conus_1km --sector-id LCC --letters --compress -f hrpt_M01_20170202_1457_22716.l1b
+    polar2grid.sh -r avhrr -w awips_tiled -p band3a_vis -g lcc_conus_1km --sector-id LCC --letters --compress -f hrpt_M01_20170202_1457_22716.l1b
 
-    polar2grid.sh avhrr awips_tiled --grid-coverage=0 -g polar_alaska_1km --sector-id Polar --letters --compress -f /avhrr
+    polar2grid.sh -r avhrr -w awips_tiled --grid-coverage=0 -g polar_alaska_1km --sector-id Polar --letters --compress -f /avhrr
 
-    polar2grid.sh avhrr hdf5 --add-geolocation --grid-configs /home/avhrr/grids/local_grid.conf -g my_grid  -f ../input/hrpt_*.l1b
+    polar2grid.sh -r avhrr -w hdf5 --add-geolocation --grid-configs /home/avhrr/grids/local_grid.conf -g my_grid  -f ../input/hrpt_*.l1b
 
-    polar2grid.sh avhrr binary -p band1_vis band4_bt -g lcc_eu -f /data/avhrr/metoba
+    polar2grid.sh -r avhrr -w binary -p band1_vis band4_bt -g lcc_eu -f /data/avhrr/metoba

--- a/integration_tests/features/polar2grid.feature
+++ b/integration_tests/features/polar2grid.feature
@@ -25,7 +25,7 @@ Feature: Test polar2grid output images
 
     Examples: AVHRR
       | command                          | source            | output             |
-      | polar2grid.sh -r avhrr -w geotiff -vv -f | avhrr/input/test1 | avhrr/output/test1 |
+      | polar2grid.sh -r avhrr_l1b_aapp -w geotiff -vv -f | avhrr/input/test1 | avhrr/output/test1 |
 
     Examples: MODIS
       | command                                                                                                                                   | source            | output             |

--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -336,6 +336,7 @@ def _supported_readers(is_polar2grid: bool = False) -> list[str]:
             "acspo",
             "amsr2_l1b",
             "amsr_l2_gaasp",
+            "avhrr_l1b_aapp",
             "clavrx",
             "mersi2_l1b",
             "mirs",

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -77,6 +77,8 @@ _PLATFORM_ALIASES = {
     "aqua": "aqua",
     "terra": "terra",
     "gcom-w1": "gcom-w1",
+    "metop-a": "metopa",
+    "metop-b": "metopb",
 }
 
 

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -111,15 +111,17 @@ def add_writer_argument_groups(parser, group=None):
         "--scale-offset-tags",
         default=["scale", "offset"],
         type=_check_tags,
-        help="Specify custom geotiff tags for enhancement metadata. Should be "
-        "two comma-separated names for the metadata tags. Defaults to "
-        "'scale,offset'. Specify 'NONE' to not save the tags.",
+        # help="Specify custom geotiff tags for enhancement metadata. Should be "
+        # "two comma-separated names for the metadata tags. Defaults to "
+        # "'scale,offset'. Specify 'NONE' to not save the tags.",
+        help=SUPPRESS,
     )
     group.add_argument(
         "--colormap-tag",
         default="colormap",
         type=lambda input_str: None if input_str == "NONE" else input_str,
-        help="Specify the custom geotiff tag where a CSV version of an applied " "colormap (if any) will be saved.",
+        # help="Specify the custom geotiff tag where a CSV version of an applied " "colormap (if any) will be saved.",
+        help=SUPPRESS,
     )
     group.add_argument(
         "--gdal-num-threads",


### PR DESCRIPTION
Satpy uses the name `avhrr-3`. For backwards compatibility we need it to be `avhrr`. This PR adds aliases for sensors in the glue script. It also updates the name of the avhrr reader in all of the documentation to match the satpy one and lists the avhrr reader in the usage text.