### PR TITLE
Fix legacy dynamic grids not working with negative resolutions

### DIFF
--- a/polar2grid/core/containers.py
+++ b/polar2grid/core/containers.py
@@ -292,7 +292,7 @@ class GridDefinition(dict):
             )
         kwargs = {}
         if self["cell_width"] is not None:
-            kwargs["resolution"] = (self["cell_width"], self["cell_height"])
+            kwargs["resolution"] = (abs(self["cell_width"]), abs(self["cell_height"]))
         return DynamicAreaDefinition(
             self["grid_name"], self["grid_name"], self.proj4_dict, self["width"], self["height"], **kwargs
         )

--- a/polar2grid/tests/test_grids/test_manager.py
+++ b/polar2grid/tests/test_grids/test_manager.py
@@ -22,9 +22,21 @@
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
 """Test grid manager."""
 
+from pyresample import AreaDefinition, DynamicAreaDefinition
+
 from polar2grid.grids import GridManager
 
 
-def test_grid_manager_basic(builtin_test_grids_conf):
+def test_grid_manager_basic(builtin_test_grids_conf, viirs_sdr_i_swath_def):
     """Test basic parsing of .conf files."""
-    GridManager(*builtin_test_grids_conf)
+    gm = GridManager(*builtin_test_grids_conf)
+    for grid_name in gm.grid_information:
+        grid_def = gm.get_grid_definition(grid_name)
+        area_def = grid_def.to_satpy_area()
+        assert isinstance(area_def, (AreaDefinition, DynamicAreaDefinition))
+        if isinstance(area_def, DynamicAreaDefinition):
+            new_area_def = area_def.freeze(viirs_sdr_i_swath_def)
+            assert new_area_def.shape[0] > 0
+            assert new_area_def.shape[1] > 0
+            assert new_area_def.area_extent[0] < new_area_def.area_extent[2]
+            assert new_area_def.area_extent[1] < new_area_def.area_extent[3]


### PR DESCRIPTION
While working on one of the integration tests I discovered that legacy grids with negative pixel resolutions (very common for legacy `y` resolutions), the resulting "frozen" AreaDefinition had a negative shape. A negative resolution in the sense that the area/grid ends up being flipped is almost never actually desired. It is rare enough that I'm removing the option of making a dynamic grid with a negative resolution. The resolution is forced to a positive value (`abs`).