### PR TITLE
Fix bundle initialization to use embedded openssl

### DIFF
--- a/swbundle/env.sh
+++ b/swbundle/env.sh
@@ -42,7 +42,7 @@ done
 THIS_SCRIPT_HOME="$( cd -P "$( dirname "$SOURCE" )" && cd .. && pwd )"
 P2G_CONDA_BASE="${THIS_SCRIPT_HOME}/libexec/python_runtime"
 P2G_METADATA="${P2G_CONDA_BASE}/lib/python*/site-packages/polar2grid-*.dist-info/METADATA"
-METADATA_CHECKSUM=$(openssl sha256 $P2G_METADATA)
+METADATA_CHECKSUM=$(${P2G_CONDA_BASE}/bin/openssl sha256 $P2G_METADATA)
 
 
 oops() {


### PR DESCRIPTION
In order to activate the environment in swbundle/env.sh, METADATA_CHECKSUM  is set using openssl. However, since the environment is not activate yet, it cannot find openssl on all systems (rockylinux:8 docker image). This merge points to the packaged environment's openssl directly.