### PR TITLE
Fix bundle creation not creating geo2grid properly

### DIFF
--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -37,7 +37,8 @@ else
     exit 1
 fi
 
-if [[ $SB_NAME == *"polar"* ]]; then
+sb_base_name=$(basename $SB_NAME)
+if [[ $sb_base_name == *"polar"* ]]; then
     PROJECT="P2G"
 else
     PROJECT="G2G"

--- a/swbundle/GEO2GRID_README.txt
+++ b/swbundle/GEO2GRID_README.txt
@@ -1,7 +1,7 @@
 Geo2Grid software bundle
 ========================
 
-Copyright (C) 2012-2019 Space Science and Engineering Center (SSEC), University of Wisconsin-Madison.
+Copyright (C) 2012-2022 Space Science and Engineering Center (SSEC), University of Wisconsin-Madison.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/swbundle/POLAR2GRID_README.txt
+++ b/swbundle/POLAR2GRID_README.txt
@@ -1,7 +1,7 @@
 Polar2Grid software bundle
 ==========================
 
-Copyright (C) 2012-2019 Space Science and Engineering Center (SSEC), University of Wisconsin-Madison.
+Copyright (C) 2012-2022 Space Science and Engineering Center (SSEC), University of Wisconsin-Madison.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
@joleenf pointed out on slack that the G2G beta tarball I gave her contained the Polar2Grid README and release notes. This PR fixes this issue. The main problem was that the swbundle creation script assumed the name of the software bundle was a single filename and not a path. If the path contains "polar" anywhere in it then the script thinks it is generating Polar2Grid instead of Geo2Grid. This ultimately isn't a big deal functionality-wise, but does matter for these smaller things like the README and release notes.