### PR TITLE
Add optimization to persist swath definition lon/lat arrays

### DIFF
--- a/doc/source/custom_grids.rst
+++ b/doc/source/custom_grids.rst
@@ -56,7 +56,7 @@ Example Grid Configuration File: :download:`grid_example.yaml <../../swbundle/gr
 
 Grid configuration files follow the format used by the Satpy and Pyresample
 Python libraries in their
-:doc:`areas.yaml files <geometry_utils>` and are in the
+:doc:`areas.yaml files <pyresample:geometry_utils>` and are in the
 `YAML text format <https://en.wikipedia.org/wiki/YAML>`_.
 Comments can be added by prefixing lines with a ``#`` character. There is an
 example file provided in the |project| bundle at:

--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -445,6 +445,17 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
         "Less than this is day, greater than or equal to "
         "this value is night.",
     )
+    group_1.add_argument(
+        "--no-persist-geolocation",
+        action="store_true",
+        # help="After data is loaded, compute all geolocation arrays and hold "
+        #      "them in memory. This should allow processing to perform faster "
+        #      "in most cases at the cost of higher memory usage. This will "
+        #      "have the biggest impact on readers whose lon/lat arrays are "
+        #      "expensive to load (ex. modis_l1b). This currently only works "
+        #      "on swath-based geolocation data and has no effect otherwise.",
+        help=argparse.SUPPRESS,
+    )
     return (group_1,)
 
 

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -354,7 +354,7 @@ class _GlueProcessor:
             return -1
         scn.load(products, **load_args)
         if persist_geolocation:
-            _persist_swath_definition_in_scene(scn)
+            scn = _persist_swath_definition_in_scene(scn)
 
         reader_args = arg_parser._reader_args
         filter_kwargs = {
@@ -391,6 +391,7 @@ class _GlueProcessor:
 
 def _persist_swath_definition_in_scene(scn: Scene) -> None:
     persisted_swath_defs = {}
+    new_scn = scn.copy()
     for data_arr in scn.values():
         swath_def = data_arr.attrs.get("area")
         if not isinstance(swath_def, SwathDefinition):
@@ -399,8 +400,12 @@ def _persist_swath_definition_in_scene(scn: Scene) -> None:
         if persisted_swath_def is None:
             persisted_swath_def = _persist_swath_definition(swath_def)
             persisted_swath_defs[swath_def] = persisted_swath_def
-        data_arr.attrs["area"] = persisted_swath_def
+        new_data_arr = data_arr.copy()
+        new_data_arr.attrs["area"] = persisted_swath_def
+        scn._datasets[data_arr.attrs["_satpy_id"]] = new_data_arr
+        # data_arr.attrs["area"] = persisted_swath_def
     LOG.debug(f"{len(persisted_swath_defs)} unique swath definitions persisted")
+    return new_scn
 
 
 def _persist_swath_definition(swath_def: SwathDefinition) -> SwathDefinition:

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -349,7 +349,7 @@ class _GlueProcessor:
             return 0
 
         products = reader_info.get_satpy_products_to_load()
-        persist_geolocation = not load_args.pop("no_persist_geolocation", True)
+        persist_geolocation = not arg_parser._reader_args.pop("no_persist_geolocation", False)
         if not products:
             return -1
         scn.load(products, **load_args)
@@ -400,6 +400,7 @@ def _persist_swath_definition_in_scene(scn: Scene) -> None:
             persisted_swath_def = _persist_swath_definition(swath_def)
             persisted_swath_defs[swath_def] = persisted_swath_def
         data_arr.attrs["area"] = persisted_swath_def
+    LOG.debug(f"{len(persisted_swath_defs)} unique swath definitions persisted")
 
 
 def _persist_swath_definition(swath_def: SwathDefinition) -> SwathDefinition:


### PR DESCRIPTION
Currently swath definitions in a dynamic grid workflow will compute longitude and latitude dask arrays 3 times:

1. Day/night product filtering
2. Dynamic grid freezing
3. Resampling

This PR adds a default behavior (with hidden flag to disable) that persists all lon/lat arrays in memory after loading. This allows all these steps to use the data that is in memory for faster performance, but at the cost of higher memory usage.