### PR TITLE
Add CF-complaint NetCDF writer (cf)

### DIFF
--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -35,8 +35,8 @@ different grids, the CF compliant workaround is to save the datasets to separate
 
 
 """
-import logging
 import json
+import logging
 
 LOG = logging.getLogger(__name__)
 
@@ -52,7 +52,6 @@ DEFAULT_OUTPUT_FILENAMES = {
 
 
 def add_writer_argument_groups(parser, group=None):
-
     if group is None:
         group = parser.add_argument_group(title="cf Writer")
     group.add_argument(

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -45,7 +45,7 @@ DEFAULT_OUTPUT_FILENAMES = {
     "polar2grid": {
         None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
     },
-    "geo2grid": {
+        "geo2grid": {
         None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
     },
 }

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -38,13 +38,11 @@ different grids, the CF compliant workaround is to save the datasets to separate
 import logging
 import json
 
-from polar2grid.core.script_utils import BooleanOptionalAction
-
 LOG = logging.getLogger(__name__)
 
 # reader_name -> filename
 DEFAULT_OUTPUT_FILENAMES = {
-        "polar2grid": {
+    "polar2grid": {
         None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
     },
     "geo2grid": {
@@ -54,7 +52,6 @@ DEFAULT_OUTPUT_FILENAMES = {
 
 
 def add_writer_argument_groups(parser, group=None):
-
     if group is None:
         group = parser.add_argument_group(title="cf Writer")
     group.add_argument(
@@ -80,8 +77,8 @@ def add_writer_argument_groups(parser, group=None):
         "--engine",
         default="netcdf4",
         help="Module to be used for writing netCDF files. Follows xarray's"
-              ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
-              "preference for 'netcdf4'.",
+             ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
+             "preference for 'netcdf4'.",
     )
     group.add_argument(
         "--epoch",

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -27,12 +27,17 @@
 #     1225 West Dayton Street
 #     Madison, WI  53706
 #     david.hoese@ssec.wisc.edu
-"""The cf writer puts gridded image data into a `CF-compliant` netCDF file.
+r"""The cf writer puts gridded image data into a `CF-compliant` netCDF file.
 
 All datasets to be saved must have the same projection coordinates ``x`` and ``y``. If a scene holds datasets with
 different grids, the CF compliant workaround is to save the datasets to separate files.
 
+Group key and list values  must use escapes before quoting.
 
+Example:
+  >>>  python glue.py -r clavrx -w cf -f clavrx_OR_ABI-L1b-RadC-M6C01_G16_s202212419011712.level2.nc \
+       -vvv -g WGS84_MESO --grid-configs mygrid.conf -p cld_press_acha cld_temp_acha --method nearest \
+       --groups "{\"WGS84_MESO\": [\"cld_press_acha\", \"cld_temp_acha\"]}"
 
 """
 import json

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -38,11 +38,13 @@ different grids, the CF compliant workaround is to save the datasets to separate
 import logging
 import json
 
+from polar2grid.core.script_utils import BooleanOptionalAction
+
 LOG = logging.getLogger(__name__)
 
 # reader_name -> filename
 DEFAULT_OUTPUT_FILENAMES = {
-    "polar2grid": {
+        "polar2grid": {
         None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
     },
         "geo2grid": {
@@ -52,6 +54,7 @@ DEFAULT_OUTPUT_FILENAMES = {
 
 
 def add_writer_argument_groups(parser, group=None):
+
     if group is None:
         group = parser.add_argument_group(title="cf Writer")
     group.add_argument(
@@ -77,8 +80,8 @@ def add_writer_argument_groups(parser, group=None):
         "--engine",
         default="netcdf4",
         help="Module to be used for writing netCDF files. Follows xarray's"
-             ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
-             "preference for 'netcdf4'.",
+              ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
+              "preference for 'netcdf4'.",
     )
     group.add_argument(
         "--epoch",

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -44,10 +44,10 @@ LOG = logging.getLogger(__name__)
 
 # reader_name -> filename
 DEFAULT_OUTPUT_FILENAMES = {
-        "polar2grid": {
+    "polar2grid": {
         None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
     },
-        "geo2grid": {
+    "geo2grid": {
         None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
     },
 }
@@ -80,8 +80,8 @@ def add_writer_argument_groups(parser, group=None):
         "--engine",
         default="netcdf4",
         help="Module to be used for writing netCDF files. Follows xarray's"
-              ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
-              "preference for 'netcdf4'.",
+        ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
+        "preference for 'netcdf4'.",
     )
     group.add_argument(
         "--epoch",
@@ -95,31 +95,30 @@ def add_writer_argument_groups(parser, group=None):
     )
     group.add_argument(
         "--no_lonlats",
-        dest='include_lonlats',
-        action='store_false',
-        help="Don't include latitude and longitude coordinates."
+        dest="include_lonlats",
+        action="store_false",
+        help="Don't include latitude and longitude coordinates.",
     )
 
-    group.add_argument(
-        "--not_pretty", dest="pretty", action='store_true',
-        help="Modify coordinate names"
-    )
+    group.add_argument("--not_pretty", dest="pretty", action="store_true", help="Modify coordinate names")
 
     group.add_argument(
-        "--no_include_orig_name", dest="include_orig_name", action='store_false',
-        help="Do not include the original dataset name as a variable attribute in the final netcdf."
+        "--no_include_orig_name",
+        dest="include_orig_name",
+        action="store_false",
+        help="Do not include the original dataset name as a variable attribute in the final netcdf.",
     )
 
     group.add_argument(
         "--flatten_attrs",
-        action='store_true',
+        action="store_true",
         help="If invoked, flatten dict-type attributes",
     )
 
     group.add_argument(
         "--numeric_name_prefix",
         default="CHANNEL_",
-        help="Prefix added to each variable. For name starting with a digit.Use '' or None to leave this out.."
+        help="Prefix added to each variable. For name starting with a digit.Use '' or None to leave this out..",
     )
 
     return group, None

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+# Copyright (C) 2018 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+#
+#     Written by David Hoese    March 2016
+#     University of Wisconsin-Madison
+#     Space Science and Engineering Center
+#     1225 West Dayton Street
+#     Madison, WI  53706
+#     david.hoese@ssec.wisc.edu
+"""The cf writer puts gridded image data into a `CF-compliant` netCDF file.
+
+All datasets to be saved must have the same projection coordinates ``x`` and ``y``. If a scene holds datasets with
+different grids, the CF compliant workaround is to save the datasets to separate files.
+
+
+
+"""
+import logging
+import json
+
+from polar2grid.core.script_utils import BooleanOptionalAction
+
+LOG = logging.getLogger(__name__)
+
+# reader_name -> filename
+DEFAULT_OUTPUT_FILENAMES = {
+        "polar2grid": {
+        None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
+    },
+    "geo2grid": {
+        None: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.nc",
+    },
+}
+
+
+def add_writer_argument_groups(parser, group=None):
+
+    if group is None:
+        group = parser.add_argument_group(title="cf Writer")
+    group.add_argument(
+        "--output-filename",
+        dest="filename",
+        help="Custom file pattern to save dataset to",
+    )
+    group.add_argument(
+        "--groups",
+        dest="groups",
+        type=json.loads,
+        help="Group datasets according to the given assignment: `{'group_name': ['dataset1', 'dataset2', ...]}`.",
+    )
+
+    group.add_argument(
+        "--header_attrs",
+        dest="header_attrs",
+        type=json.loads,
+        help="Global attributes to be included.",
+    )
+
+    group.add_argument(
+        "--engine",
+        default="netcdf4",
+        help="Module to be used for writing netCDF files. Follows xarray's"
+              ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
+              "preference for 'netcdf4'.",
+    )
+    group.add_argument(
+        "--epoch",
+        help="Reference time for encoding of time coordinates",
+    )
+
+    group.add_argument(
+        "--exclude_attrs",
+        nargs="+",
+        help="List of dataset attributes to be excluded",
+    )
+    group.add_argument(
+        "--no_lonlats",
+        dest='include_lonlats',
+        action='store_false',
+        help="Don't include latitude and longitude coordinates."
+    )
+
+    group.add_argument(
+        "--not_pretty", dest="pretty", action='store_true',
+        help="Modify coordinate names"
+    )
+
+    group.add_argument(
+        "--no_include_orig_name", dest="include_orig_name", action='store_false',
+        help="Do not include the original dataset name as a variable attribute in the final netcdf."
+    )
+
+    group.add_argument(
+        "--flatten_attrs",
+        action='store_true',
+        help="If invoked, flatten dict-type attributes",
+    )
+
+    group.add_argument(
+        "--numeric_name_prefix",
+        default="CHANNEL_",
+        help="Prefix added to each variable. For name starting with a digit.Use '' or None to leave this out.."
+    )
+
+    return group, None

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -27,17 +27,10 @@
 #     1225 West Dayton Street
 #     Madison, WI  53706
 #     david.hoese@ssec.wisc.edu
-r"""The cf writer puts gridded image data into a `CF-compliant` netCDF file.
+"""The cf writer puts gridded image data into a `CF-compliant` netCDF file.
 
 All datasets to be saved must have the same projection coordinates ``x`` and ``y``. If a scene holds datasets with
 different grids, the CF compliant workaround is to save the datasets to separate files.
-
-Group key and list values  must use escapes before quoting.
-
-Example:
-  >>>  python glue.py -r clavrx -w cf -f clavrx_OR_ABI-L1b-RadC-M6C01_G16_s202212419011712.level2.nc \
-       -vvv -g WGS84_MESO --grid-configs mygrid.conf -p cld_press_acha cld_temp_acha --method nearest \
-       --groups "{\"WGS84_MESO\": [\"cld_press_acha\", \"cld_temp_acha\"]}"
 
 """
 import json

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-# Copyright (C) 2018 Space Science and Engineering Center (SSEC),
+# Copyright (C) 2022 Space Science and Engineering Center (SSEC),
 #  University of Wisconsin-Madison.
 #
 #     This program is free software: you can redistribute it and/or modify
@@ -20,14 +20,7 @@
 # satellite observation data, remaps it, and writes it to a file format for
 # input into another program.
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
-#
-#     Written by David Hoese    March 2016
-#     University of Wisconsin-Madison
-#     Space Science and Engineering Center
-#     1225 West Dayton Street
-#     Madison, WI  53706
-#     david.hoese@ssec.wisc.edu
-"""The cf writer puts gridded image data into a `CF-compliant` netCDF file.
+"""The CF writer puts gridded image data into a `CF-compliant` NetCDF file.
 
 All datasets to be saved must have the same projection coordinates ``x`` and ``y``. If a scene holds datasets with
 different grids, the CF compliant workaround is to save the datasets to separate files.
@@ -65,7 +58,7 @@ def add_writer_argument_groups(parser, group=None):
     )
 
     group.add_argument(
-        "--header_attrs",
+        "--header-attrs",
         dest="header_attrs",
         type=json.loads,
         help="Global attributes to be included.",
@@ -74,44 +67,49 @@ def add_writer_argument_groups(parser, group=None):
     group.add_argument(
         "--engine",
         default="netcdf4",
-        help="Module to be used for writing netCDF files. Follows xarray's"
-        ":meth:`~xarray.Dataset.to_netcdf` engine choices with a"
-        "preference for 'netcdf4'.",
+        help="Engine for writing NetCDF file \
+             (options: '"
+        "netcdf4"
+        "', '"
+        "scipy"
+        "', '"
+        "h5netcdf"
+        "').",
     )
-    group.add_argument(
-        "--epoch",
-        help="Reference time for encoding of time coordinates",
-    )
+    group.add_argument("--epoch-units", dest="epoch", help="Reference unit for the netCDF time coordinates.")
 
     group.add_argument(
-        "--exclude_attrs",
+        "--exclude-attrs",
+        dest="--exclude_attrs",
         nargs="+",
         help="List of dataset attributes to be excluded",
     )
     group.add_argument(
-        "--no_lonlats",
+        "--include-lonlats",
         dest="include_lonlats",
-        action="store_false",
-        help="Don't include latitude and longitude coordinates.",
+        action="store_true",
+        help="Include latitude and longitude coordinates.",
     )
 
-    group.add_argument("--not_pretty", dest="pretty", action="store_true", help="Modify coordinate names")
+    group.add_argument("--pretty", action="store_true", help="Do not prefix coordinate with corresponding dataset name")
 
     group.add_argument(
-        "--no_include_orig_name",
+        "--include-orig-name",
         dest="include_orig_name",
-        action="store_false",
-        help="Do not include the original dataset name as a variable attribute in the final netcdf.",
+        action="store_true",
+        help="Include the original dataset name as a variable attribute in the final netcdf.",
     )
 
     group.add_argument(
-        "--flatten_attrs",
+        "--flatten-attrs",
+        dest="--flatten_attrs",
         action="store_true",
         help="If invoked, flatten dict-type attributes",
     )
 
     group.add_argument(
-        "--numeric_name_prefix",
+        "--numeric-name-prefix",
+        dest="--numeric_name_prefix",
         default="CHANNEL_",
         help="Prefix added to each variable. For name starting with a digit.Use '' or None to leave this out..",
     )

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -38,8 +38,6 @@ different grids, the CF compliant workaround is to save the datasets to separate
 import logging
 import json
 
-from polar2grid.core.script_utils import BooleanOptionalAction
-
 LOG = logging.getLogger(__name__)
 
 # reader_name -> filename

--- a/polar2grid/writers/cf.py
+++ b/polar2grid/writers/cf.py
@@ -52,14 +52,12 @@ def add_writer_argument_groups(parser, group=None):
     )
     group.add_argument(
         "--groups",
-        dest="groups",
         type=json.loads,
         help="Group datasets according to the given assignment: `{'group_name': ['dataset1', 'dataset2', ...]}`.",
     )
 
     group.add_argument(
         "--header-attrs",
-        dest="header_attrs",
         type=json.loads,
         help="Global attributes to be included.",
     )
@@ -80,13 +78,11 @@ def add_writer_argument_groups(parser, group=None):
 
     group.add_argument(
         "--exclude-attrs",
-        dest="--exclude_attrs",
         nargs="+",
         help="List of dataset attributes to be excluded",
     )
     group.add_argument(
         "--include-lonlats",
-        dest="include_lonlats",
         action="store_true",
         help="Include latitude and longitude coordinates.",
     )
@@ -95,21 +91,18 @@ def add_writer_argument_groups(parser, group=None):
 
     group.add_argument(
         "--include-orig-name",
-        dest="include_orig_name",
         action="store_true",
         help="Include the original dataset name as a variable attribute in the final netcdf.",
     )
 
     group.add_argument(
         "--flatten-attrs",
-        dest="--flatten_attrs",
         action="store_true",
         help="If invoked, flatten dict-type attributes",
     )
 
     group.add_argument(
         "--numeric-name-prefix",
-        dest="--numeric_name_prefix",
         default="CHANNEL_",
         help="Prefix added to each variable. For name starting with a digit.Use '' or None to leave this out..",
     )


### PR DESCRIPTION
Meant to resolve issue #471.  

1. The DEFAULT_OUTPUT_FILENAMES are wrong if an alternate engine is used.  What is the best way to deal with this in polar2grid...no default?
2. The boolean options are reversed for glue.  Most use a flag that negate the satpy flag.  Is there a better way to deal with this.
3. Command line dictionaries get pretty ugly in the glue.py call.  Is there a preferred way to deal with this in polar2grid?
ex.). python ~/code/polar2grid/polar2grid/glue.py -r clavrx -w cf -f /Users/joleenf/data/p2g/clavrx/meso/clavrx_OR_ABI-L1b-RadC-M6C01_G16_s202212419011712.level2.nc -g WGS84_MESO --grid-configs mygrid.conf -p cld_press_acha cld_temp_acha --groups "{\ \"WGS84_MESO\\": [\\"cld_press_acha\\", \\"cld_temp_acha\\"]}" --method nearest -vvv