### PR TITLE
Add --no-mask-space flag to AHI HSD reader

### DIFF
--- a/polar2grid/readers/ahi_hsd.py
+++ b/polar2grid/readers/ahi_hsd.py
@@ -98,6 +98,7 @@ from __future__ import annotations
 from argparse import ArgumentParser, _ArgumentGroup
 from typing import Optional
 
+from ..core.script_utils import BooleanOptionalAction
 from ._base import ReaderProxyBase
 
 READER_PRODUCTS = ["B{:02d}".format(x) for x in range(1, 17)]
@@ -138,4 +139,5 @@ def add_reader_argument_groups(
     """
     if group is None:
         group = parser.add_argument_group(title="AHI HSD Reader")
+    group.add_argument("--mask-space", action=BooleanOptionalAction, default=True, help="Mask space pixels.")
     return group, None


### PR DESCRIPTION
Some users would like more control over the edge of the disk for AHI HSD data. There is a flag in satpy to control the default behavior of masking space pixels. Masking space pixels saves on output image size and rarely includes a lot of useful data (especially for people wanting to view Earth observations from Earth-observing satellites :wink: ). The new flag turns this behavior off.