### PR TITLE
Fix persisting geolocations not actually persisting

### DIFF
--- a/polar2grid/filters/day_night.py
+++ b/polar2grid/filters/day_night.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 @cache
-def _get_sunlight_coverage(area_def, start_time, sza_threshold=90, overpass=None):
+def _get_sunlight_coverage(area_def, start_time, sza_threshold=90.0, overpass=None):
     """Get the sunlight coverage of *area_def* at *start_time* as a value between 0 and 1."""
     if area_def.ndim == 1:
         logger.debug("Source data is 1 dimensional, will not filter based on sunlight coverage.")

--- a/polar2grid/resample/_resample_scene.py
+++ b/polar2grid/resample/_resample_scene.py
@@ -153,7 +153,7 @@ class AreaDefResolver:
     def _freeze_area_if_dynamic(self, area_def: PRGeometry) -> PRGeometry:
         if isinstance(area_def, DynamicAreaDefinition):
             logger.info("Computing dynamic grid parameters...")
-            area_def = area_def.freeze(self.input_scene.max_area())
+            area_def = area_def.freeze(self.input_scene.finest_area())
             logger.debug("Frozen dynamic area: %s", area_def)
         return area_def
 
@@ -257,7 +257,11 @@ def _redict_hashable_kwargs(kwargs_tuple):
 
 def _get_default_resampler(resampler, area_name, area_def, input_scene):
     if resampler is None and area_def is not None:
-        rs = "native" if area_name in ["MIN", "MAX"] or _is_native_grid(area_def, input_scene.max_area()) else "nearest"
+        rs = (
+            "native"
+            if area_name in ["MIN", "MAX"] or _is_native_grid(area_def, input_scene.finest_area())
+            else "nearest"
+        )
         logger.debug("Setting default resampling to '{}' for grid '{}'".format(rs, area_name))
     else:
         rs = resampler

--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -39,6 +39,15 @@ def pytest_configure(config):
     add_polar2grid_config_paths()
 
 
+@pytest.fixture(autouse=True)
+def clear_cached_functions():
+    from polar2grid.filters._utils import polygon_for_area
+    from polar2grid.filters.day_night import _get_sunlight_coverage
+
+    _get_sunlight_coverage.cache_clear()
+    polygon_for_area.cache_clear()
+
+
 @pytest.fixture
 def chtmpdir(tmp_path: Path):
     lwd = os.getcwd()

--- a/polar2grid/tests/test_resample/test_resample_scene.py
+++ b/polar2grid/tests/test_resample/test_resample_scene.py
@@ -234,7 +234,7 @@ def test_partial_filter(viirs_sdr_i01_data_array):
     new_scn["I01_2"] = new_i01
 
     # computation 1: input swath 1 polygon
-    # computation 3: input swath 2 polygon (filtered and not resampled)
+    # computation 2: input swath 2 polygon (filtered and not resampled)
     with dask.config.set(scheduler=CustomScheduler(2)):
         scenes_to_save = resample_scene(
             new_scn,


### PR DESCRIPTION
In an effort to improve #423, I noticed that the swath persisting logic implemented in #472 wasn't actually holding on to the persisted data. It was a simple logic bug, but an important one. It meant that the lon/lats were being persisted (computed) but then immediately discarded and never used. So it basically did each geolocation load and interpolation at least one extra time more than it had to.