### PR TITLE
Split reader loading and composite generation for better geolocation persisting

### DIFF
--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -352,9 +352,10 @@ class _GlueProcessor:
         persist_geolocation = not arg_parser._reader_args.pop("no_persist_geolocation", False)
         if not products:
             return -1
-        scn.load(products, **load_args)
+        scn.load(products, **load_args, generate=False)
         if persist_geolocation:
             scn = _persist_swath_definition_in_scene(scn)
+        scn.generate_possible_composites(True)
 
         reader_args = arg_parser._reader_args
         filter_kwargs = {


### PR DESCRIPTION
This PR switches the product loading and composite generation so it loads the reader datasets, persists swath geolocation, then generates composites. This should make sure that any composites or modifiers that use the lon/lat information will use the persisted version of the data instead of recomputing these arrays.