### PR TITLE
Add geotiff --overviews-resampling flag

### DIFF
--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -140,6 +140,12 @@ def add_writer_argument_groups(parser, group=None):
         "typically as powers of 2. Example: '2 4 8 16'",
     )
     group.add_argument(
+        "--overviews-resampling",
+        default="nearest",
+        choices=("nearest", "average", "bilinear", "cubic", "cubicspline", "lanczos"),
+        help="Specify resampling used when generating overviews",
+    )
+    group.add_argument(
         "--gdal-driver",
         dest="driver",
         help="Name of the GDAL driver to use when writing the geotiff. "


### PR DESCRIPTION
This allows users to control what resampling is used when generating overviews. I need this for GeoSphere to completely move overview generation into Satpy/G2G instead of using `gdal_translate` as a separate step.