### PR TITLE
Add reader-specific default dask chunk sizes

### DIFF
--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -48,6 +48,7 @@ from polar2grid.filters import filter_scene
 from polar2grid.readers._base import ReaderProxyBase
 from polar2grid.resample import resample_scene
 from polar2grid.utils.config import add_polar2grid_config_paths
+from polar2grid.utils.dynamic_imports import get_reader_attr
 
 LOG = logging.getLogger(__name__)
 
@@ -331,6 +332,8 @@ class _GlueProcessor:
     def _run_processing(self):
         LOG.info("Sorting and reading input files...")
         arg_parser = self.arg_parser
+        preferred_chunk_size = get_reader_attr(arg_parser._scene_creation["reader"], "PREFERRED_CHUNK_SIZE", 1024)
+        _set_preferred_chunk_size(preferred_chunk_size)
         scn = _create_scene(arg_parser._scene_creation)
         if scn is None:
             return -1
@@ -388,6 +391,17 @@ class _GlueProcessor:
         compute_writer_results(to_save)
         LOG.info("SUCCESS")
         return 0
+
+
+def _set_preferred_chunk_size(preferred_chunk_size: int) -> None:
+    pcs_in_mb = (preferred_chunk_size * preferred_chunk_size) * 8 // (1024 * 1024)
+    if "PYTROLL_CHUNK_SIZE" not in os.environ:
+        LOG.debug(f"Setting preferred chunk size to {preferred_chunk_size} pixels or {pcs_in_mb:d}MiB")
+        satpy.CHUNK_SIZE = preferred_chunk_size
+        os.environ["PYTROLL_CHUNK_SIZE"] = f"{preferred_chunk_size:d}"
+        dask.config.set({"array.chunk-size": f"{pcs_in_mb:d}MiB"})
+    else:
+        LOG.debug(f"Using environment variable chunk size: {os.environ['PYTROLL_CHUNK_SIZE']}")
 
 
 def _persist_swath_definition_in_scene(scn: Scene) -> None:

--- a/polar2grid/readers/abi_l1b.py
+++ b/polar2grid/readers/abi_l1b.py
@@ -103,6 +103,8 @@ from typing import Optional
 
 from ._base import ReaderProxyBase
 
+PREFERRED_CHUNK_SIZE: int = 1356
+
 READER_PRODUCTS = ["C{:02d}".format(x) for x in range(1, 17)]
 COMPOSITE_PRODUCTS = [
     "true_color",

--- a/polar2grid/readers/abi_l2_nc.py
+++ b/polar2grid/readers/abi_l2_nc.py
@@ -54,6 +54,8 @@ from typing import Optional
 
 from ._base import ReaderProxyBase
 
+PREFERRED_CHUNK_SIZE: int = 1356
+
 READER_PRODUCTS = [
     "HT",
     "TEMP",

--- a/polar2grid/readers/agri_l1.py
+++ b/polar2grid/readers/agri_l1.py
@@ -92,6 +92,8 @@ from typing import Optional
 
 from ._base import ReaderProxyBase
 
+PREFERRED_CHUNK_SIZE: int = 4096
+
 READER_PRODUCTS = ["C{:02d}".format(x) for x in range(1, 15)]
 COMPOSITE_PRODUCTS = [
     "true_color",
@@ -105,7 +107,7 @@ COMPOSITE_PRODUCTS = [
 class ReaderProxy(ReaderProxyBase):
     """Provide Polar2Grid-specific information about this reader's products."""
 
-    is_geo2grid_reader = True
+    is_geo2grid_reader: bool = True
 
     def get_default_products(self) -> list[str]:
         """Get products to load if users hasn't specified any others."""

--- a/polar2grid/readers/ahi_hsd.py
+++ b/polar2grid/readers/ahi_hsd.py
@@ -101,6 +101,8 @@ from typing import Optional
 from ..core.script_utils import BooleanOptionalAction
 from ._base import ReaderProxyBase
 
+PREFERRED_CHUNK_SIZE: int = 2200  # one segment
+
 READER_PRODUCTS = ["B{:02d}".format(x) for x in range(1, 17)]
 COMPOSITE_PRODUCTS = [
     "true_color",

--- a/polar2grid/readers/modis_l1b.py
+++ b/polar2grid/readers/modis_l1b.py
@@ -140,6 +140,8 @@ from polar2grid.core.script_utils import ExtendConstAction
 
 from ._base import ReaderProxyBase
 
+PREFERRED_CHUNK_SIZE: int = 1400  # at least one 1km swath width
+
 FILTERS = {
     "day_only": {
         "standard_name": [

--- a/polar2grid/readers/modis_l2.py
+++ b/polar2grid/readers/modis_l2.py
@@ -72,6 +72,8 @@ from satpy import DataQuery
 
 from ._base import ReaderProxyBase
 
+PREFERRED_CHUNK_SIZE: int = 1400  # at least one 1km swath width
+
 PRODUCTS = [
     "cloud_mask",
     "land_sea_mask",

--- a/polar2grid/readers/viirs_sdr.py
+++ b/polar2grid/readers/viirs_sdr.py
@@ -186,6 +186,8 @@ from polar2grid.core.script_utils import ExtendConstAction
 
 from ._base import ReaderProxyBase
 
+PREFERRED_CHUNK_SIZE: int = 6400
+
 I_PRODUCTS = [
     "I01",
     "I02",

--- a/swbundle/geo2grid.sh
+++ b/swbundle/geo2grid.sh
@@ -37,8 +37,6 @@ export POLAR2GRID_HOME="$( cd -P "$( dirname "$SOURCE" )" && cd .. && pwd )"
 
 # Set best known defaults for number of OpenMP threads
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-2}
-# and dask chunk size
-export PYTROLL_CHUNK_SIZE=${PYTROLL_CHUNK_SIZE:-1024}
 
 # Call the python module to do the processing, passing all arguments
 export PROG_NAME="geo2grid.sh"

--- a/swbundle/polar2grid.sh
+++ b/swbundle/polar2grid.sh
@@ -37,8 +37,6 @@ export POLAR2GRID_HOME="$( cd -P "$( dirname "$SOURCE" )" && cd .. && pwd )"
 
 # Set best known defaults for number of OpenMP threads
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-2}
-# and dask chunk size
-export PYTROLL_CHUNK_SIZE=${PYTROLL_CHUNK_SIZE:-1024}
 
 # Call the python module to do the processing, passing all arguments
 export PROG_NAME="polar2grid.sh"


### PR DESCRIPTION
This PR has a major effect on performance. By choosing dask chunk sizes related to the scanning patterns of the instrument or related to the on-disk file chunk sizes we can drastically improve processing speed. The original default that is used for Polar2Grid and Geo2Grid was based on manual testing with ABI L1b data and was set to 1024. Even this is sub-optimal as it would be best to align to the file chunk size of 226 (1354 is divisible by 226 and creates 16 equal sized chunks across a 500m full disk image). For AGRI this is extremely important where the file chunks are 4096 and doing anything less than that will still require loading the 4096x4096 chunk and then slicing the requested dask chunk size out (~25m for true_color processing to ~3m). For VIIRS and MODIS, the files are generally chunked per granule (VIIRS) or per scan (MODIS) so loading anything not aligned with that negatively affects performance. It is also important with these instruments to not split up a scan in the column/width dimension as EWA and interpolation steps require entire scans.

This PR sets some logical default chunk sizes for the most commonly used readers and those most affected by the current default chunk size.