### PR TITLE
Add --antimeridian-mode for dynamic grid handling

### DIFF
--- a/build_environment.yml
+++ b/build_environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - pykdtree
   - pyorbital>=1.7.2
   - pyproj>=3.1.0
-  - pyresample>=1.24.1
+  - pyresample>=1.25.0
   - pyshp
   - pyspectral>=0.11.0
   - python=3.10

--- a/etc/writers/awips_tiled.yaml
+++ b/etc/writers/awips_tiled.yaml
@@ -1,0 +1,717 @@
+# Originally converted from the CSPP Polar2Grid SCMI Writer
+# Some datasets are named differently and have not been converted to
+# Satpy-style naming yet. These config entries are commented out.
+writer:
+  name: awips_tiled
+  description: AWIPS-compatible Tiled NetCDF4 Writer
+  writer: !!python/name:satpy.writers.awips_tiled.AWIPSTiledWriter
+  compress: True
+templates:
+  polar:
+    variables:
+      # VIIRS Corrected Reflectance
+      viirs_crefl01:
+        name: viirs_crefl01
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.67 um CR
+          units: {}
+      viirs_crefl02:
+        name: viirs_crefl02
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.87 um CR
+          units: {}
+      viirs_crefl03:
+        name: viirs_crefl03
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.49 um CR
+          units: {}
+      viirs_crefl04:
+        name: viirs_crefl04
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.56 um CR
+          units: {}
+      viirs_crefl05:
+        name: viirs_crefl05
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.24 um CR
+          units: {}
+      viirs_crefl06:
+        name: viirs_crefl06
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.61 um CR
+          units: {}
+      viirs_crefl07:
+        name: viirs_crefl07
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 2.25 um CR
+          units: {}
+      viirs_crefl08:
+        name: viirs_crefl08
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.64 um CR
+          units: {}
+      viirs_crefl09:
+        name: viirs_crefl09
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.87 um CR
+          units: {}
+      viirs_crefl10:
+        name: viirs_crefl10
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.61 um CR
+          units: {}
+
+      # MODIS L1B Products
+      modis_vis01:
+        name: vis01
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.65 um
+          units: {}
+      modis_vis02:
+        name: vis02
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.86 um
+          units: {}
+      modis_vis03:
+        name: vis03
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.47 um
+          units: {}
+      modis_vis04:
+        name: vis04
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.56 um
+          units: {}
+      modis_vis05:
+        name: vis05
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.24 um
+          units: {}
+      modis_vis06:
+        name: vis06
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.64 um
+          units: {}
+      modis_vis07:
+        name: vis07
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 2.13 um
+          units: {}
+      modis_vis26:
+        name: vis26
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.38 um
+          units: {}
+      modis_bt20:
+        name: bt20
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 3.75 um
+          units: {}
+      modis_bt21:
+        name: bt21
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: Fire
+          units: {}
+      modis_bt22:
+        name: bt22
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 3.96 um
+          units: {}
+      modis_bt23:
+        name: bt23
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 4.05 um
+          units: {}
+      modis_bt24:
+        name: bt24
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 4.47 um
+          units: {}
+      modis_bt25:
+        name: bt25
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 4.52 um
+          units: {}
+      modis_bt27:
+        name: bt27
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 6.7 um
+          units: {}
+      modis_bt28:
+        name: bt28
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 7.3 um
+          units: {}
+      modis_bt29:
+        name: bt29
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 8.6 um
+          units: {}
+      modis_bt30:
+        name: bt30
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 9.7 um
+          units: {}
+      modis_bt31:
+        name: bt31
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 11.0 um
+          units: {}
+      modis_bt32:
+        name: bt32
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 12.0 um
+          units: {}
+      modis_bt33:
+        name: bt33
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 13.3 um
+          units: {}
+      modis_bt34:
+        name: bt34
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 13.6 um
+          units: {}
+      modis_bt35:
+        name: bt35
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 13.9 um
+          units: {}
+      modis_bt36:
+        name: bt36
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 14.2 um
+          units: {}
+      modis_sst:
+        name: sst
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: SST
+          units: {}
+      modis_lst:
+        name: lst
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: LST
+          units: {}
+      modis_slst:
+        name: slst
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: LSTSUM
+          units: {}
+      modis_fog:
+        name: ssec_fog
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: Fog
+          units: {}
+      modis_ctt:
+        name: ctt
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: CTT
+          units: {}
+      modis_ndvi:
+        name: ndvi
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: NDVI
+          units: {}
+      modis_tpw:
+        name: tpw
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: TPW
+          units: {}
+      modis_ice_concentration:
+        name: ice_concentration
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: Ice Concentration
+          units: {}
+      modis_ist:
+        name: ist
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: Ice Surface Temperature
+          units: {}
+
+      # MODIS L1B Corrected Reflectances
+      modis_crefl01_250m:
+        name: modis_crefl01_250m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.65 um CR
+          units: {}
+      modis_crefl01_500m:
+        name: modis_crefl01_250m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.65 um CR
+          units: {}
+      modis_crefl01_1000m:
+        name: modis_crefl01_1000m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.65 um CR
+          units: {}
+      modis_crefl02_250m:
+        name: modis_crefl02_250m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.86 um CR
+          units: {}
+      modis_crefl02_500m:
+        name: modis_crefl02_500m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.86 um CR
+          units: {}
+      modis_crefl02_1000m:
+        name: modis_crefl02_1000m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.86 um CR
+          units: {}
+      modis_crefl03_250m:
+        name: modis_crefl03_250m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.47 um CR
+          units: {}
+      modis_crefl03_500m:
+        name: modis_crefl03_500m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.47 um CR
+          units: {}
+      modis_crefl03_1000m:
+        name: modis_crefl03_1000m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.47 um CR
+          units: {}
+      modis_crefl04_250m:
+        name: modis_crefl04_250m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.56 um CR
+          units: {}
+      modis_crefl04_500m:
+        name: modis_crefl04_500m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.56 um CR
+          units: {}
+      modis_crefl04_1000m:
+        name: modis_crefl04_1000m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 0.56 um CR
+          units: {}
+      modis_crefl05_500m:
+        name: modis_crefl05_500m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.24 um CR
+          units: {}
+      modis_crefl05_1000m:
+        name: modis_crefl05_1000m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.24 um CR
+          units: {}
+      modis_crefl06_500m:
+        name: modis_crefl06_500m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.64 um CR
+          units: {}
+      modis_crefl06_1000m:
+        name: modis_crefl06_1000m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 1.64 um CR
+          units: {}
+      modis_crefl07_500m:
+        name: modis_crefl07_500m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 2.13 um CR
+          units: {}
+      modis_crefl07_1000m:
+        name: modis_crefl07_1000m
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: 2.13 um CR
+          units: {}
+
+      # MIRS Products
+      mirs_btemp_23v:
+        name: btemp_23v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 23 GHZ V
+          units: {}
+      mirs_btemp_31v:
+        name: btemp_31v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 31 GHZ V
+          units: {}
+      mirs_btemp_50h:
+        name: btemp_50h
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 50 GHZ H
+          units: {}
+      mirs_btemp_51h:
+        name: btemp_51h
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 51 GHZ H
+          units: {}
+      mirs_btemp_52h:
+        name: btemp_52h
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 52 GHZ H
+          units: {}
+      mirs_btemp_53h:
+        name: btemp_53h
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 53 GHZ H
+          units: {}
+      mirs_btemp_54h1:
+        name: btemp_54h1
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 54 GHZ H-1
+          units: {}
+      mirs_btemp_54h2:
+        name: btemp_54h2
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 54 GHZ H-2
+          units: {}
+      mirs_btemp_55h:
+        name: btemp_55h
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 55 GHZ H
+          units: {}
+      mirs_btemp_57h1:
+        name: btemp_57h1
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 57 GHZ H-1
+          units: {}
+      mirs_btemp_57h2:
+        name: btemp_57h2
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 57 GHZ H-2
+          units: {}
+      mirs_btemp_57h3:
+        name: btemp_57h3
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 57 GHZ H-3
+          units: {}
+      mirs_btemp_57h4:
+        name: btemp_57h4
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 57 GHZ H-4
+          units: {}
+      mirs_btemp_57h5:
+        name: btemp_57h5
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 57 GHZ H-5
+          units: {}
+      mirs_btemp_57h6:
+        name: btemp_57h6
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 57 GHZ H-6
+          units: {}
+      mirs_btemp_88v:
+        name: btemp_88v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 88 GHZ V
+          units: {}
+      mirs_btemp_165h:
+        name: btemp_165h
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 165 GHZ H
+          units: {}
+      mirs_btemp_183h1:
+        name: btemp_183h1
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 183 GHZ H-1
+          units: {}
+      mirs_btemp_183h2:
+        name: btemp_183h2
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 183 GHZ H-2
+          units: {}
+      mirs_btemp_183h3:
+        name: btemp_183h3
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 183 GHZ H-3
+          units: {}
+      mirs_btemp_183h4:
+        name: btemp_183h4
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 183 GHZ H-4
+          units: {}
+      mirs_btemp_183h5:
+        name: btemp_183h5
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 183 GHZ H-5
+          units: {}
+
+      # MIRS BTs - NOAA-18 - AMSU-A MHS
+      # MIRS BTs - NOAA-19 - AMSU-A MHS
+      # MIRS BTs - M1 (metopb) - AMSU-A MHS
+      # MIRS BTs - M2 (metopa) - AMSU-A MHS
+      mirs_btemp_50v:
+        name: btemp_50v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 50 GHZ V
+          units: {}
+      mirs_btemp_52v:
+        name: btemp_52v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 52 GHZ V
+          units: {}
+      mirs_btemp_54h:
+        name: btemp_54h
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 54 GHZ H
+          units: {}
+      mirs_btemp_54v:
+        name: btemp_54v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 54 GHZ V
+          units: {}
+      mirs_btemp_89v1:
+        name: btemp_89v1
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 89 GHZ V-1
+          units: {}
+      mirs_btemp_89v2:
+        name: btemp_89v2
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 89 GHZ V-2
+          units: {}
+      # 157h on OPSO NOAA site
+      mirs_btemp_157v:
+        name: btemp_157v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 157 GHZ V
+          units: {}
+      mirs_btemp_190v:
+        name: btemp_190v
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS 190 GHZ V
+          units: {}
+      mirs_rain_rate:
+        reader: mirs
+        name: rain_rate
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS Rain Rate
+          units: {}
+      mirs_snow_cover:
+        reader: mirs
+        name: snow_cover
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS Snow Cover
+          units: {}
+      mirs_sea_ice:
+        reader: mirs
+        name: sea_ice
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS Sea Ice
+          units: {}
+      mirs_swe:
+        reader: mirs
+        name: swe
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS SWE
+          units: {}
+      mirs_clw:
+        reader: mirs
+        name: clw
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS CLW
+          units: {}
+      mirs_tpw:
+        reader: mirs
+        name: tpw
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS TPW
+          units: {}
+      mirs_tskin:
+        reader: mirs
+        name: tskin
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS Skin Temperature
+          units: {}

--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -585,6 +585,7 @@ def add_resample_argument_groups(parser, is_polar2grid=None):
             nargs="*",
             help='Area definition to resample to. Empty means no resampling (default: "MAX")',
         )
+
     # shared options
     group_1.add_argument(
         "--grid-coverage",
@@ -616,6 +617,19 @@ def add_resample_argument_groups(parser, is_polar2grid=None):
         "Coordinates must be valid in the source data "
         "projection. Can only be used with gridded "
         "input data.",
+    )
+    group_1.add_argument(
+        "--antimeridian-mode",
+        default="modify_crs",
+        choices=("modify_extents", "modify_crs", "global_extents"),
+        help="Behavior when dynamic grids are converted to 'frozen' grids and "
+        "data crosses the anti-meridian. Defaults to 'modify_crs' where "
+        "the prime meridian is shifted 180 degrees to make the result one "
+        "contiguous coordinate space. 'modify_extents' will attempt to "
+        "surround the data but will often cause artifacts over the "
+        "antimeridian. 'global_extents' will force the X extents to -180 "
+        "and 180 to create one large grid. This currently only affects "
+        "lon/lat projections.",
     )
 
     # nearest neighbor resampling

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -239,11 +239,13 @@ def _resample_scene_to_grids(
         return []
 
     areas_to_resample = resample_args.pop("grids")
+    antimeridian_mode = resample_args.pop("antimeridian_mode")
     if "ewa_persist" in resample_args:
         resample_args["persist"] = resample_args.pop("ewa_persist")
     scenes_to_save = resample_scene(
         scn,
         areas_to_resample,
+        antimeridian_mode=antimeridian_mode,
         preserve_resolution=preserve_resolution,
         is_polar2grid=use_polar2grid_defaults,
         **resample_args,

--- a/polar2grid/resample/_resample_scene.py
+++ b/polar2grid/resample/_resample_scene.py
@@ -146,14 +146,14 @@ class AreaDefResolver:
         area_def = _get_area_def_from_name(area_name, self.input_scene, self.grid_manager, self.yaml_areas)
         return area_def
 
-    def get_frozen_area(self, area_name: Optional[str]) -> Optional[PRGeometry]:
+    def get_frozen_area(self, area_name: Optional[str], **kwargs) -> Optional[PRGeometry]:
         area_def = self[area_name]
-        return self._freeze_area_if_dynamic(area_def)
+        return self._freeze_area_if_dynamic(area_def, **kwargs)
 
-    def _freeze_area_if_dynamic(self, area_def: PRGeometry) -> PRGeometry:
+    def _freeze_area_if_dynamic(self, area_def: PRGeometry, **kwargs) -> PRGeometry:
         if isinstance(area_def, DynamicAreaDefinition):
             logger.info("Computing dynamic grid parameters...")
-            area_def = area_def.freeze(self.input_scene.finest_area())
+            area_def = area_def.freeze(self.input_scene.finest_area(), **kwargs)
             logger.debug("Frozen dynamic area: %s", area_def)
         return area_def
 
@@ -163,6 +163,7 @@ def resample_scene(
     areas_to_resample: ListOfAreas,
     grid_configs: list[str, ...],
     resampler: Optional[str],
+    antimeridian_mode: str = "modify_crs",
     preserve_resolution: bool = True,
     grid_coverage: Optional[float] = None,
     is_polar2grid: bool = True,
@@ -189,7 +190,7 @@ def resample_scene(
         if _grid_cov is None:
             _grid_cov = 0.1
         for area_name in areas:
-            area_def = area_resolver.get_frozen_area(area_name)
+            area_def = area_resolver.get_frozen_area(area_name, antimeridian_mode=antimeridian_mode)
             has_dynamic_extents = area_resolver.has_dynamic_extents(area_name)
             rs = _get_default_resampler(resampler, area_name, area_def, input_scene)
             new_scn = _filter_and_resample_scene_to_single_area(


### PR DESCRIPTION
Adds `--antimeridian-mode` for when dynamic grids are converted to static grids and the input data crosses the lon/lat antimeridian (-180/180). This currently only affects lon/lat projections (not mercator, not polar-stereographic, etc). It defaults to backwards Polar2Grid compatibility via `modify_crs`. Other options are `modify_extents` and `global_extents`. See pyresample `DynamicAreaDefinition.freeze` method documentation for more information.

This PR also includes #492.