### PR TITLE
Hide --ll-bbox CLI option for Polar2Grid

### DIFF
--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -612,7 +612,9 @@ def add_resample_argument_groups(parser, is_polar2grid=None):
         nargs=4,
         type=float,
         metavar=("lon_min", "lat_min", "lon_max", "lat_max"),
-        help="Crop data to region specified by lon/lat "
+        help=argparse.SUPPRESS
+        if is_polar2grid
+        else "Crop data to region specified by lon/lat "
         "bounds (lon_min lat_min lon_max lat_max). "
         "Coordinates must be valid in the source data "
         "projection. Can only be used with gridded "


### PR DESCRIPTION
This flag currently doesn't work for swath based products (Satpy/pyresample can't do it without hurting performance) so it was decided that it would just be better to hide the option for Polar2Grid.

Closes #500 