### PR TITLE
Fix add_coastlines.py using the wrong colorbar limits when geotiff contains a colormap

### DIFF
--- a/polar2grid/tests/test_add_coastlines.py
+++ b/polar2grid/tests/test_add_coastlines.py
@@ -21,6 +21,7 @@
 # input into another program.
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
 """Basic usability tests for the add_coastlines script."""
+import contextlib
 import os
 from unittest import mock
 
@@ -29,10 +30,15 @@ import pytest
 import rasterio
 from PIL import Image
 
-REDS_CMAP = {
+REDS_SPREAD_CMAP = {
     0: (0, 0, 0, 255),
     128: (128, 0, 0, 255),
     255: (255, 0, 0, 255),
+}
+REDS_MIN_CMAP = {
+    0: (0, 0, 0, 255),
+    1: (128, 0, 0, 255),
+    2: (255, 0, 0, 255),
 }
 
 
@@ -57,93 +63,154 @@ def _shared_fake_geotiff_kwargs(num_bands):
     return kwargs
 
 
-def _shared_fake_l_geotiff_data():
+def _shared_fake_l_geotiff_data(colormap: dict[int, tuple]):
+    colormap_values = sorted(colormap.keys()) if colormap is not None else [0, 128, 255]
     data = np.zeros((500, 1000), dtype=np.uint8)
-    data[200:300, :] = 128
-    data[300:, :] = 255
+    data[:] = colormap_values[0]
+    data[200:300, :] = colormap_values[1]
+    data[300:, :] = colormap_values[2]
     return data
 
 
-def _create_fake_l_geotiff(fp, include_colormap_tag=False):
+def _shared_fake_rgb_geotiff_data(colormap: dict[int, tuple]):
+    colormap_values = [color[0] for color in colormap.values()]
+    data = np.zeros((500, 1000), dtype=np.uint8)
+    data[:] = colormap_values[0]
+    data[200:300, :] = colormap_values[1]
+    data[300:, :] = colormap_values[2]
+
+    r_data = data
+    g_data = np.zeros_like(r_data)
+    b_data = np.zeros_like(r_data)
+    return r_data, g_data, b_data
+
+
+def _create_fake_l_geotiff(fp, colormap=None, include_scale_offset=False, include_colormap_tag=False):
     kwargs = _shared_fake_geotiff_kwargs(1)
     with rasterio.open(fp, "w", **kwargs) as ds:
-        ds.write(_shared_fake_l_geotiff_data(), 1)
-        if include_colormap_tag:
-            ds.update_tags(**_create_csv_cmap_and_extra_tags())
+        ds.write(_shared_fake_l_geotiff_data(colormap), 1)
+        if include_scale_offset:
+            ds.update_tags(scale=0.5, offset=0.0)
+        # include_colormap_tag is not used because there is no logical way to
+        # create a L geotiff that also has no colormap
 
 
-def _create_fake_rgb_geotiff(fp, include_colormap_tag=False):
+def _create_fake_rgb_geotiff(fp, colormap=None, include_scale_offset=False, include_colormap_tag=False):
     kwargs = _shared_fake_geotiff_kwargs(3)
     with rasterio.open(fp, "w", **kwargs) as ds:
-        r_data = _shared_fake_l_geotiff_data()
+        r_data, g_data, b_data = _shared_fake_rgb_geotiff_data(colormap)
         ds.write(r_data, 1)
-        ds.write(np.zeros_like(r_data), 2)
-        ds.write(np.zeros_like(r_data), 3)
+        ds.write(g_data, 2)
+        ds.write(b_data, 3)
+        if include_scale_offset:
+            ds.update_tags(scale=0.5, offset=0.0)
         if include_colormap_tag:
-            ds.update_tags(**_create_csv_cmap_and_extra_tags())
+            ds.update_tags(**_create_csv_cmap_and_extra_tags(colormap))
 
 
-def _create_fake_rgb_geotiff_with_factor_offset(fp, include_colormap_tag=False):
-    kwargs = _shared_fake_geotiff_kwargs(3)
-    with rasterio.open(fp, "w", **kwargs) as ds:
-        r_data = _shared_fake_l_geotiff_data()
-        ds.write(r_data, 1)
-        ds.write(np.zeros_like(r_data), 2)
-        ds.write(np.zeros_like(r_data), 3)
-        ds.update_tags(scale=0.5, offset=0.0)
-        if include_colormap_tag:
-            ds.update_tags(**_create_csv_cmap_and_extra_tags())
-
-
-def _create_fake_l_geotiff_colormap(fp, include_colormap_tag=False):
+def _create_fake_l_geotiff_colormap(fp, colormap=None, include_scale_offset=False, include_colormap_tag=False):
     kwargs = _shared_fake_geotiff_kwargs(1)
     with rasterio.open(fp, "w", **kwargs) as ds:
-        ds.write(_shared_fake_l_geotiff_data(), 1)
-        ds.write_colormap(1, REDS_CMAP)
-        if include_colormap_tag:
-            ds.update_tags(**_create_csv_cmap_and_extra_tags())
+        ds.write(_shared_fake_l_geotiff_data(colormap), 1)
+        if colormap is not None:
+            ds.write_colormap(1, colormap)
+        if include_scale_offset:
+            ds.update_tags(scale=0.5, offset=0.0)
+        if colormap is not None and include_colormap_tag:
+            ds.update_tags(**_create_csv_cmap_and_extra_tags(colormap))
 
 
-def _create_csv_cmap_and_extra_tags():
-    cmap_csv = [",".join(str(x) for x in [v] + list(color)) for v, color in REDS_CMAP.items()]
+def _create_csv_cmap_and_extra_tags(colormap):
+    cmap_csv = [",".join(str(x) for x in [v] + list(color)) for v, color in colormap.items()]
     cmap_csv_str = "\n".join(cmap_csv)
     return {"colormap": cmap_csv_str}
 
 
 @pytest.mark.parametrize(
-    ("gen_func", "has_colors", "create_cmap_tag"),
+    ("gen_func", "include_scale_offset", "include_cmap_tag"),
     [
         (_create_fake_l_geotiff, False, False),
+        (_create_fake_l_geotiff_colormap, False, False),
         (_create_fake_l_geotiff_colormap, True, False),
+        (_create_fake_l_geotiff_colormap, True, True),
+        (_create_fake_rgb_geotiff, False, True),
         (_create_fake_rgb_geotiff, True, True),
-        (_create_fake_rgb_geotiff_with_factor_offset, True, True),
     ],
 )
+@pytest.mark.parametrize("colormap", [REDS_SPREAD_CMAP, REDS_MIN_CMAP])
 @mock.patch("polar2grid.add_coastlines.ContourWriterAGG.add_overlay_from_dict")
-def test_add_coastlines_basic(add_overlay_mock, tmp_path, gen_func, has_colors, create_cmap_tag):
+def test_add_coastlines_basic(add_overlay_mock, tmp_path, gen_func, include_scale_offset, include_cmap_tag, colormap):
     from polar2grid.add_coastlines import main
 
+    is_rgb = "rgb" in gen_func.__name__
+    has_colormap = "colormap" in gen_func.__name__
+    has_colors = colormap is not None and (has_colormap or is_rgb)
+
     fp = str(tmp_path / "test.tif")
-    gen_func(fp, include_colormap_tag=create_cmap_tag)
+    gen_func(fp, colormap, include_scale_offset=include_scale_offset, include_colormap_tag=include_cmap_tag)
     extra_args = []
-    ret = main(["--add-coastlines", "--add-colorbar", fp] + extra_args)
+
+    with mocked_pydecorate_add_scale() as add_scale_mock:
+        ret = main(["--add-coastlines", "--add-colorbar", fp] + extra_args)
+
     assert ret in [None, 0]
     assert os.path.isfile(tmp_path / "test.png")
     add_overlay_mock.assert_called_once()
     assert "coasts" in add_overlay_mock.call_args.args[0]
+    add_scale_mock.assert_called_once()
+    passed_cmap = add_scale_mock.call_args.kwargs["colormap"]
+    _check_used_colormap(passed_cmap, has_colors, include_cmap_tag, include_scale_offset)
+
     img = Image.open(tmp_path / "test.png")
     arr = np.asarray(img)
     # bottom of the image is a colorbar
     image_arr = arr[:940]
-    r_uniques = np.unique(image_arr[:, :, 0])
-    np.testing.assert_allclose(r_uniques, [0, 128, 255])
-    g_colors = [0] if has_colors else [0, 128, 255]
-    g_uniques = np.unique(image_arr[:, :, 1])
-    np.testing.assert_allclose(g_uniques, g_colors)
-    b_colors = [0] if has_colors else [0, 128, 255]
-    b_uniques = np.unique(image_arr[:, :, 2])
-    np.testing.assert_allclose(b_uniques, b_colors)
+    _check_exp_image_colors(image_arr, colormap, 0, has_colors)
+    _check_exp_image_colors(image_arr, colormap, 1, has_colors)
+    _check_exp_image_colors(image_arr, colormap, 2, has_colors)
     assert (arr[940:] != 0).any()
+
+
+def _check_used_colormap(passed_cmap, has_colors, include_cmap_tag, include_scale_offset):
+    cmin = passed_cmap.values[0]
+    cmax = passed_cmap.values[-1]
+    cmap_size = passed_cmap.values.size
+    exp_cmap_size = 255 if not has_colors or not include_cmap_tag else 3
+    exp_cmin = 0.0
+    exp_cmax = 255.0 if not has_colors or not include_scale_offset else 127.5
+    assert cmap_size == exp_cmap_size
+    assert cmin == exp_cmin
+    assert cmax == exp_cmax
+
+    if not has_colors:
+        # no colormap, pure black colorbar
+        np.testing.assert_allclose(passed_cmap.colors[:, :3], 0)
+
+
+def _check_exp_image_colors(image_arr, colormap, color_idx, has_colors):
+    exp_raw_values = list(colormap.keys())
+    cmap_colors = list(set(color[color_idx] for color in colormap.values()))
+    exp_colors = cmap_colors if has_colors else exp_raw_values
+    r_uniques = np.unique(image_arr[:, :, color_idx])
+    np.testing.assert_allclose(r_uniques, exp_colors)
+
+
+@contextlib.contextmanager
+def mocked_pydecorate_add_scale():
+    from polar2grid.add_coastlines import DecoratorAGG
+
+    add_scale_mock = mock.Mock()
+    decorator_mock = mock.Mock()
+
+    def _create_decorator(img):
+        dec = DecoratorAGG(img)
+        add_scale_mock.side_effect = dec.add_scale
+        dec.add_scale = add_scale_mock
+        return dec
+
+    decorator_mock.side_effect = _create_decorator
+    with mock.patch("polar2grid.add_coastlines.DecoratorAGG", decorator_mock):
+        yield add_scale_mock
 
 
 @mock.patch("polar2grid.add_coastlines.ContourWriterAGG.add_overlay_from_dict")


### PR DESCRIPTION
This PR fixes an issue that has existed since changes were made to colormap'ing in Satpy/Polar2Grid. There was a change made in trollimage that added scaling and offset information and eventually included a new `colormap` tag with a CSV version of the colormap that was applied. If the colormap is added with `add_colormap.sh` (what I would consider a "legacy" way of doing this), then that attribute is not available. In both of these cases where the geotiff has a colormap built in the add_coastlines script thought scale factor and offset were based on a 0 to 1 scale. This was the original way that trollimage was going to work with these attributes but was changed last minute and apparently I never updated polar2grid to reflect this.