### PR TITLE
Add ability to specify single enhancement YAML to --extra-config-path and other fixes

### DIFF
--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -122,6 +122,7 @@ class GlueArgumentParser:
 
         reader_subgroups = _add_component_parser_args(parser, "readers", known_args.readers or [])
         writer_subgroups = _add_component_parser_args(parser, "writers", known_args.writers or [])
+        self.argv = argv
         self._args = parser.parse_args(argv)
         _validate_reader_writer_args(parser, self._args, self._is_polar2grid)
 
@@ -251,7 +252,9 @@ def _add_common_arguments(parser: argparse.ArgumentParser, binary_name: str) -> 
         "files. For example, to use custom enhancement YAML file named "
         "'generic.yaml' place it in a directory called 'enhancements' "
         "like '/path/to/my_configs/enhancements/generic.yaml' and then "
-        "set this flag to '/path/to/my_configs'.",
+        "set this flag to '/path/to/my_configs'. For backwards compatibility, "
+        "with older versions, this flag can also be given a single enhancement "
+        "YAML configuration file.",
     )
     parser.add_argument(
         "--match-resolution",

--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -23,12 +23,14 @@
 """Test initialization and fixtures."""
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
 import pytest
 
 PKG_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
+root_logger = logging.getLogger()
 
 pytest_plugins = ["polar2grid.tests._abi_fixtures", "polar2grid.tests._viirs_fixtures"]
 
@@ -66,3 +68,11 @@ def builtin_grids_yaml() -> list[str]:
 @pytest.fixture(scope="session")
 def builtin_test_grids_conf() -> list[str]:
     return [os.path.join(PKG_ROOT, "tests", "etc", "grids.conf")]
+
+
+@pytest.fixture(autouse=True)
+def ensure_logging_framework_not_altered():
+    """Protect logger handlers to avoid capsys closing files."""
+    before_handlers = list(root_logger.handlers)
+    yield
+    root_logger.handlers = before_handlers

--- a/polar2grid/tests/test_glue.py
+++ b/polar2grid/tests/test_glue.py
@@ -29,6 +29,7 @@ from unittest import mock
 
 import dask
 import pytest
+import yaml
 from pytest_lazyfixture import lazy_fixture
 from satpy.tests.utils import CustomScheduler
 
@@ -77,6 +78,119 @@ VIIRS_SDR_FILENAMES = [
     "SVM15_npp_d20120225_t1801245_e1802487_b01708_c20120226002348350715_noaa_ops.h5",
     "SVM16_npp_d20120225_t1801245_e1802487_b01708_c20120226002204855751_noaa_ops.h5",
 ]
+
+
+@pytest.fixture(scope="session")
+def extra_viirs_composite_path(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("extra_viirs_composite_path")
+    _create_fake_comp(tmp_path)
+    _create_fake_comp_enh(tmp_path)
+    yield [tmp_path]
+
+
+def _create_fake_comp(tmp_path):
+    from satpy.composites import GenericCompositor
+
+    comps_dict = {
+        "composites": {
+            "myfakecomp": {
+                "compositor": GenericCompositor,
+                "prerequisites": [
+                    {"name": "I01"},
+                    {"name": "I01"},
+                    {"name": "I01"},
+                ],
+                "standard_name": "myfakecomp",
+            },
+        },
+    }
+
+    comp_path = tmp_path / "composites"
+    comp_path.mkdir(parents=True)
+    viirs_comp_path = comp_path / "viirs.yaml"
+    with open(viirs_comp_path, "w") as comp_file:
+        yaml.dump(comps_dict, comp_file)
+
+
+def _create_fake_comp_enh(tmp_path):
+    from satpy.enhancements import stretch
+
+    enh_dict = {
+        "enhancements": {
+            "myfakecomp_default": {
+                "standard_name": "myfakecomp",
+                "operations": [
+                    {
+                        "name": "myfakecomp_stretch",
+                        "method": stretch,
+                        "kwargs": {"stretch": "crude", "min_stretch": 0, "max_stretch": 1},
+                    },
+                ],
+            },
+        },
+    }
+
+    enh_path = tmp_path / "enhancements"
+    enh_path.mkdir(parents=True)
+    viirs_enh_file = enh_path / "viirs.yaml"
+    with open(viirs_enh_file, "w") as comp_file:
+        yaml.dump(enh_dict, comp_file)
+
+
+@pytest.fixture(scope="session")
+def extra_viirs_enhancement_file(tmp_path_factory):
+    import yaml
+    from satpy.enhancements import stretch
+
+    tmp_path = tmp_path_factory.mktemp("extra_viirs_enhancement_file")
+
+    enh_dict = {
+        "enhancements": {
+            "myfakeenh_i01": {
+                "name": "I01",
+                "operations": [
+                    {
+                        "name": "myfakeenh_i01_stretch",
+                        "method": stretch,
+                        "kwargs": {"stretch": "crude", "min_stretch": 0, "max_stretch": 1},
+                    },
+                ],
+            },
+            "myfakecomp_new_default": {
+                "name": "myfakecomp",
+                "standard_name": "myfakecomp",
+                "operations": [
+                    {
+                        "name": "myfakecomp_new_stretch",
+                        "method": stretch,
+                        "kwargs": {"stretch": "crude", "min_stretch": 0, "max_stretch": 1},
+                    },
+                ],
+            },
+        },
+    }
+
+    enh_path = tmp_path / "enhancements"
+    enh_path.mkdir(parents=True)
+    viirs_enh_file = enh_path / "blahblahblah.yaml"
+    with open(viirs_enh_file, "w") as comp_file:
+        yaml.dump(enh_dict, comp_file)
+    yield [viirs_enh_file]
+
+
+@pytest.fixture(scope="session")
+def extra_viirs_comp_and_enh(extra_viirs_composite_path, extra_viirs_enhancement_file):
+    yield extra_viirs_composite_path + extra_viirs_enhancement_file
+
+
+@contextlib.contextmanager
+def prepare_glue_exec(create_scene_func, max_computes=0, use_polar2grid=True):
+    use_str = "1" if use_polar2grid else "0"
+    with set_env(USE_POLAR2GRID_DEFAULTS=use_str), mock.patch(
+        "polar2grid.glue._create_scene"
+    ) as create_scene, dask.config.set(scheduler=CustomScheduler(max_computes)):
+        create_scene.return_value = create_scene_func
+        yield
 
 
 def _create_empty_viirs_sdrs(dst_dir):
@@ -140,10 +254,7 @@ class TestGlueFakeScene:
     def test_abi_scene(self, scene_fixture, product_names, num_outputs, max_computes, chtmpdir):
         from polar2grid.glue import main
 
-        with set_env(USE_POLAR2GRID_DEFAULTS="0"), mock.patch(
-            "polar2grid.glue._create_scene"
-        ) as create_scene, dask.config.set(scheduler=CustomScheduler(max_computes)):
-            create_scene.return_value = scene_fixture
+        with prepare_glue_exec(scene_fixture, max_computes=max_computes, use_polar2grid=False):
             ret = main(["-r", "abi_l1b", "-w", "geotiff", "-f", str(chtmpdir), "-p"] + product_names)
         output_files = glob(str(chtmpdir / "*.tif"))
         assert len(output_files) == num_outputs
@@ -173,10 +284,7 @@ class TestGlueFakeScene:
     def test_viirs_sdr_scene(self, scene_fixture, product_names, num_outputs, extra_flags, max_computes, chtmpdir):
         from polar2grid.glue import main
 
-        with set_env(USE_POLAR2GRID_DEFAULTS="1"), mock.patch(
-            "polar2grid.glue._create_scene"
-        ) as create_scene, dask.config.set(scheduler=CustomScheduler(max_computes)):
-            create_scene.return_value = scene_fixture
+        with prepare_glue_exec(scene_fixture, max_computes=max_computes):
             args = ["-r", "viirs_sdr", "-w", "geotiff", "-vvv", "-f", str(chtmpdir)]
             if product_names:
                 args.append("-p")
@@ -187,3 +295,37 @@ class TestGlueFakeScene:
         output_files = glob(str(chtmpdir / "*.tif"))
         assert len(output_files) == num_outputs
         assert ret == 0
+
+    @pytest.mark.parametrize(
+        ("extra_config_path", "exp_comps", "exp_enh_names"),
+        [
+            (lazy_fixture("extra_viirs_composite_path"), ["myfakecomp"], ["myfakecomp_stretch", "gamma"]),
+            (lazy_fixture("extra_viirs_enhancement_file"), [], ["myfakeenh_i01_stretch"]),
+            (
+                lazy_fixture("extra_viirs_comp_and_enh"),
+                ["myfakecomp"],
+                ["myfakeenh_i01_stretch", "myfakecomp_new_stretch"],
+            ),
+        ],
+    )
+    def test_extra_config_path(
+        self, extra_config_path, exp_comps, exp_enh_names, viirs_sdr_full_scene, chtmpdir, capsys
+    ):
+        from polar2grid.glue import main
+
+        args = ["-r", "viirs_sdr", "-w", "geotiff", "-vvv", "-f", str(chtmpdir)]
+        for extra_path in extra_config_path:
+            args += ["--extra-config-path", str(extra_path)]
+        with prepare_glue_exec(viirs_sdr_full_scene):
+            ret = main(args + ["--list-products-all"])
+        assert ret == 0
+        captured = capsys.readouterr()
+        for exp_comp in exp_comps:
+            assert exp_comp in captured.out
+
+        with prepare_glue_exec(viirs_sdr_full_scene, max_computes=4):
+            ret = main(args + ["-p"] + exp_comps + ["i01"])
+        assert ret == 0
+        captured = capsys.readouterr()
+        for exp_enh_name in exp_enh_names:
+            assert exp_enh_name in captured.err

--- a/polar2grid/writers/hdf5.py
+++ b/polar2grid/writers/hdf5.py
@@ -230,7 +230,6 @@ class HDF5Writer(Writer):
         dtype=None,
         append=True,
         compute=True,
-        chunks=None,
         **kwargs,
     ):
         """Save HDF5 datasets."""
@@ -337,13 +336,18 @@ def add_writer_argument_groups(parser, group=None):
         type=str_to_dtype,
         help="Data type of the output file (8-bit unsigned " "integer by default - uint8)",
     )
-    group.add_argument("--compress", default="LZW", help="File compression algorithm (DEFLATE, LZW, NONE, etc)")
+    group.add_argument(
+        "--compress",
+        dest="compression",
+        choices=["none", "gzip", "lzf"],  # , "szip"],
+        default="none",
+        help="Dataset compression algorithm. Defaults to no compression.",
+    )
     group.add_argument(
         "--add-geolocation",
         action="store_true",
         help="Add 'longitude' and 'latitude' datasets for each grid",
     )
-
     group.add_argument(
         "--no-append",
         dest="append",

--- a/swbundle/download_pyspectral_data.sh
+++ b/swbundle/download_pyspectral_data.sh
@@ -35,5 +35,20 @@ export POLAR2GRID_HOME="$( cd -P "$( dirname "$SOURCE" )" && cd .. && pwd )"
 # Setup necessary environments
 # __SWBUNDLE_ENVIRONMENT_INJECTION__
 
+set -e
+
+ORIG_PSP_DATA_ROOT=${PSP_DATA_ROOT}
+if [ -n "${PSP_DATA_CACHE_ROOT}" ]; then
+  echo "Using pyspectral data cache root: ${PSP_DATA_CACHE_ROOT}"
+  export PSP_DATA_ROOT=${PSP_DATA_CACHE_ROOT}
+fi
+
 # Call the python module to do the processing, passing all arguments
-python3 -c "from pyspectral.utils import download_luts, download_rsr; download_luts(); download_rsr()"
+python3 -c "from pyspectral.rayleigh import check_and_download; import logging; logging.basicConfig(level=logging.DEBUG); check_and_download()"
+python3 -c "from pyspectral.rsr_reader import check_and_download; import logging; logging.basicConfig(level=logging.DEBUG); check_and_download()"
+
+if [ -n "${PSP_DATA_CACHE_ROOT}" ]; then
+  mkdir -p "${ORIG_PSP_DATA_ROOT}"
+  cp -r ${PSP_DATA_CACHE_ROOT}/* "${ORIG_PSP_DATA_ROOT}/"
+  export PSP_DATA_ROOT=${ORIG_PSP_DATA_ROOT}
+fi


### PR DESCRIPTION
* `--extra-config-path` can now receive a single YAML enhancement file. A temporary directory will be made, the file will be renamed to `generic.yaml`, and the temporary directory will be used as an additional Satpy configuration directory. Closes #506 
* Add missing `--bt-channels` flag to mirs reader. Closes #512 
* Fix HDF5 writer `--compress` flag not working.

I really should have made these separate PRs but I got lazy.