### PR TITLE
Fix backwards compatibility for --output-filename in more writers

### DIFF
--- a/polar2grid/tests/test_utils/test_legacy_compat.py
+++ b/polar2grid/tests/test_utils/test_legacy_compat.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Copyright (C) 2021 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Tests for legacy handling utilities."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
+
+
+@pytest.mark.parametrize(
+    ("input_str", "exp_str", "num_exp_warnings"),
+    [
+        ("{p2g_name}_{start_time:%Y%m%d_%H%M%S}.tif", "{p2g_name}_{start_time:%Y%m%d_%H%M%S}.tif", 0),
+        (
+            "{satellite}_{instrument}_{product_name}_{begin_time}.tif",
+            "{platform_name}_{sensor}_{p2g_name}_{start_time:%Y%m%d_%H%M%S}.tif",
+            4,
+        ),
+        (
+            "{grid_name}_{product_name}_{begin_time_HHMM}_{end_time_HHMM}.tif",
+            "{area.area_id}_{p2g_name}_{start_time:%H%M}_{end_time:%H%M}.tif",
+            4,
+        ),
+    ],
+)
+def test_pattern_formatting(input_str, exp_str, num_exp_warnings, caplog):
+    with caplog.at_level(logging.WARNING):
+        new_str = convert_p2g_pattern_to_satpy(input_str)
+    assert new_str == exp_str
+    legacy_warns = [record for record in caplog.records if "to avoid this warning" in record.message]
+    assert len(legacy_warns) == num_exp_warnings

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -60,6 +60,7 @@ def convert_p2g_pattern_to_satpy(pattern):
         "instrument": "sensor",
         "begin_time": "start_time",
         "product_name": "p2g_name",
+        "grid_name": "area.area_id",
     }
     # If there is no other formatting before replacing begin_time,
     # add the old default formatting to the pattern and changed begin_time to

--- a/polar2grid/writers/awips_tiled.py
+++ b/polar2grid/writers/awips_tiled.py
@@ -84,6 +84,7 @@ see the Satpy documentation :mod:`here <satpy.writers.awips_tiled>`.
 import logging
 
 from polar2grid.core.script_utils import BooleanOptionalAction
+from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
 
 LOG = logging.getLogger(__name__)
 
@@ -111,6 +112,7 @@ def add_writer_argument_groups(parser, group=None):
     group.add_argument(
         "--output-filename",
         dest="filename",
+        type=convert_p2g_pattern_to_satpy,
         help="custom file pattern to save dataset to",
     )
     group.add_argument(

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -50,6 +50,7 @@ from polar2grid.core.dtype import (
     str_to_dtype,
 )
 from polar2grid.core.script_utils import NumpyDtypeList
+from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +138,7 @@ def add_writer_argument_groups(parser, group=None):
     group.add_argument(
         "--output-filename",
         dest="filename",
+        type=convert_p2g_pattern_to_satpy,
         help="Custom file pattern to save dataset to",
     )
     group.add_argument(

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -44,6 +44,7 @@ import os
 
 from polar2grid.core.dtype import NUMPY_DTYPE_STRS, int_or_float, str_to_dtype
 from polar2grid.core.script_utils import BooleanOptionalAction, NumpyDtypeList
+from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
 
 LOG = logging.getLogger(__name__)
 
@@ -69,6 +70,7 @@ def add_writer_argument_groups(parser, group=None):
     group.add_argument(
         "--output-filename",
         dest="filename",
+        type=convert_p2g_pattern_to_satpy,
         help="Custom file pattern to save dataset to",
     )
     group.add_argument(


### PR DESCRIPTION
This PR adds some backwards compatibility for people who used the old (and removed) `--filename-pattern` command line flag. This flag has been renamed `--output-filename` to be more clear about what it is, but now also uses Satpy-based metadata. This PR adds an extra step in this output naming by renaming old filename-pattern elements (ex. `grid_name`) to map to the new naming (ex. `area.area_id`). This mostly already existed thanks to @joleenf, but this PR adds it for more writers.