### PR TITLE
Add user custom products to --list-products output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
     rev: 22.8.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
-        language_version: python3.9 # Should be a command that runs python3.6+
+        language_version: python3 # Should be a command that runs python3.6+
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
       - id: isort
-        language_version: python3.9
+        language_version: python3
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -165,18 +165,18 @@ def _print_list_products(reader_info, is_polar2grid: bool, p2g_only: bool):
     available_satpy_names = ["*" + _sname for _sname in available_satpy_names]
     available_custom_names = ["*" + _sname for _sname in available_custom_names]
     project_name = "Polar2Grid" if is_polar2grid else "Geo2Grid"
-    if available_satpy_names and not p2g_only:
-        print("### Custom/Satpy Products")
-        print("\n".join(sorted(available_satpy_names)) + "\n")
-    if available_custom_names:
-        print("### Custom User Products")
-        print("\n".join(sorted(available_custom_names)) + "\n")
+
+    print("### Custom User Products")
+    print("\n".join(sorted(available_custom_names)) if available_custom_names else "<None>")
+    print()
+
+    if not p2g_only:
+        print("### Non-standard Satpy Products")
+        print("\n".join(sorted(available_satpy_names)) if available_satpy_names else "<None>")
+        print()
 
     print(f"### Standard Available {project_name} Products")
-    if not available_p2g_names:
-        print("<None>")
-    else:
-        print("\n".join(sorted(available_p2g_names)))
+    print("\n".join(sorted(available_p2g_names)) if available_p2g_names else "<None>")
 
 
 def _create_scene(scene_creation: dict) -> Optional[Scene]:

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -161,14 +161,18 @@ def _write_scene_with_writer(scn: Scene, writer_name: str, data_ids: list[DataID
 
 
 def _print_list_products(reader_info, is_polar2grid: bool, p2g_only: bool):
-    available_satpy_names, available_p2g_names = reader_info.get_available_products()
+    available_p2g_names, available_custom_names, available_satpy_names = reader_info.get_available_products()
     available_satpy_names = ["*" + _sname for _sname in available_satpy_names]
+    available_custom_names = ["*" + _sname for _sname in available_custom_names]
     project_name = "Polar2Grid" if is_polar2grid else "Geo2Grid"
     if available_satpy_names and not p2g_only:
         print("### Custom/Satpy Products")
-        print("\n".join(available_satpy_names) + "\n")
-    if not p2g_only:
-        print(f"### Standard Available {project_name} Products")
+        print("\n".join(sorted(available_satpy_names)) + "\n")
+    if available_custom_names:
+        print("### Custom User Products")
+        print("\n".join(sorted(available_custom_names)) + "\n")
+
+    print(f"### Standard Available {project_name} Products")
     if not available_p2g_names:
         print("<None>")
     else:

--- a/polar2grid/readers/viirs_sdr.py
+++ b/polar2grid/readers/viirs_sdr.py
@@ -292,6 +292,16 @@ DEFAULT_PRODUCTS = I_ALIASES + M_ALIASES + DNB_PRODUCTS[1:] + TRUE_COLOR_PRODUCT
 P2G_PRODUCTS = I_ALIASES + M_ALIASES + DNB_PRODUCTS + I_RAD_PRODUCTS + M_RAD_PRODUCTS
 P2G_PRODUCTS += I_ANGLE_PRODUCTS + M_ANGLE_PRODUCTS + DNB_ANGLE_PRODUCTS + OTHER_COMPS
 P2G_PRODUCTS += TRUE_COLOR_PRODUCTS + FALSE_COLOR_PRODUCTS
+P2G_PRODUCTS += [
+    "viirs_crefl01",
+    "viirs_crefl02",
+    "viirs_crefl03",
+    "viirs_crefl04",
+    "viirs_crefl07",
+    "viirs_crefl08",
+    "viirs_crefl09",
+]
+P2G_PRODUCTS += ["dynamic_dnb_saturation", "unsharp_true_color"]
 
 FILTERS = {
     "day_only": {

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -213,12 +213,13 @@ class AliasHandler:
             logger.debug("Mapping Satpy ID to P2G name: %s -> %s", data_id, p2g_name)
 
     def available_product_names(
-        self, all_p2g_products: list[str], available_satpy_ids: list[DataID]
-    ) -> tuple[list[str], list[str]]:
+        self, all_p2g_products: list[str], available_custom_ids: list[DataID], available_satpy_ids: list[DataID]
+    ) -> tuple[list[str], list[str], list[str]]:
         """Get separate lists of available Satpy products and Polar2Grid products."""
         available_ids_as_p2g_names = list(self.convert_satpy_to_p2g_name(available_satpy_ids, all_p2g_products))
         satpy_id_to_p2g_name = dict(zip(available_satpy_ids, available_ids_as_p2g_names))
         available_p2g_names = []
+        available_custom_names = []
         available_satpy_names = []
         for satpy_id in available_satpy_ids:
             p2g_name = satpy_id_to_p2g_name[satpy_id]
@@ -227,8 +228,10 @@ class AliasHandler:
                 continue
             if p2g_name in all_p2g_products:
                 available_p2g_names.append(p2g_name)
+            elif satpy_id in available_custom_ids:
+                available_custom_names.append(p2g_name)
             else:
                 available_satpy_names.append(satpy_id["name"])
 
         available_satpy_names = sorted(set(available_satpy_names))
-        return available_satpy_names, available_p2g_names
+        return available_p2g_names, available_custom_names, available_satpy_names


### PR DESCRIPTION
Closes #505 

Here is my best attempt at doing what is described in #505. @kathys I think we'll have to talk about what products actually show up in standard versus custom products. Maybe I need to add a new category of "hidden" products. Hopefully the examples below show what I mean. I talked with @scottlindstrom and he suggested that user products should go first, then satpy (in the `--list-products-all` case), then standard products.

Questions:
1. If there are no products available the P2G standard products will list `<None>` under the section header. Should it do that for the other sections. For now, after talking to Scott again, I think the sections should always be there with the indication that there are no products.

## VIIRS --list-products

```
$ polar2grid.sh -r viirs_sdr -w geotiff -f /data/satellite/viirs/conus_day/*t1801*.h5 --list-products
INFO     : Sorting and reading input files...
INFO     : Loading product metadata from files...
INFO     : Using default product list: ['i01', 'i02', 'i03', 'i04', 'i05', 'm01', 'm02', 'm03', 'm04', 'm05', 'm06', 'm07', 'm08', 'm09', 'm10', 'm11', 'm12', 'm13', 'm14', 'm15', 'm16', 'adaptive_dnb', 'dynamic_dnb', 'hncc_dnb', 'true_color', 'false_color', 'ifog']
### Custom User Products
*dynamic_dnb_saturation
*unsharp_true_color
*viirs_crefl01
*viirs_crefl02
*viirs_crefl03
*viirs_crefl04
*viirs_crefl07
*viirs_crefl08
*viirs_crefl09

### Standard Available Polar2Grid Products
adaptive_dnb
dnb_lunar_azimuth_angle
...
i03
i03_rad
i04
i04_rad
i05
i05_rad
i_sat_azimuth_angle
i_sat_zenith_angle
i_solar_azimuth_angle
i_solar_zenith_angle
ifog
...
m_solar_zenith_angle
true_color
```

## VIIRS --list-products-all

```
$ polar2grid.sh -r viirs_sdr -w geotiff -f /data/satellite/viirs/conus_day/*t1801*.h5 --list-products-all
INFO     : Sorting and reading input files...
INFO     : Loading product metadata from files...
INFO     : Using default product list: ['i01', 'i02', 'i03', 'i04', 'i05', 'm01', 'm02', 'm03', 'm04', 'm05', 'm06', 'm07', 'm08', 'm09', 'm10', 'm11', 'm12', 'm13', 'm14', 'm15', 'm16', 'adaptive_dnb', 'dynamic_dnb', 'hncc_dnb', 'true_color', 'false_color', 'ifog']
### Custom User Products
*dynamic_dnb_saturation
*unsharp_true_color
*viirs_crefl01
*viirs_crefl02
*viirs_crefl03
*viirs_crefl04
*viirs_crefl07
*viirs_crefl08
*viirs_crefl09

### Non-standard Satpy Products
*DNB
...
*true_color_lowres_marine_tropical
*true_color_raw

### Standard Available Polar2Grid Products
adaptive_dnb
dnb_lunar_azimuth_angle
dnb_lunar_zenith_angle
...
```

## ABI --list-products

```
$ geo2grid.sh -r abi_l1b -w geotiff -f /data/satellite/abi/20170920/*.nc --list-products
INFO     : Sorting and reading input files...
INFO     : Loading product metadata from files...
INFO     : Using default product list: ['C01', 'C02', 'C03', 'C04', 'C05', 'C06', 'C07', 'C08', 'C09', 'C10', 'C11', 'C12', 'C13', 'C14', 'C15', 'C16', 'true_color', 'natural_color']
### Custom User Products
*true_color_night

### Standard Available Geo2Grid Products
C01
...
C16
airmass
ash
dust
fog
natural_color
night_microphysics
true_color
```

## ABI --list-products-all

```
$ geo2grid.sh -r abi_l1b -w geotiff -f /data/satellite/abi/20170920/*.nc --list-products-all
INFO     : Sorting and reading input files...
INFO     : Loading product metadata from files...
INFO     : Using default product list: ['C01', 'C02', 'C03', 'C04', 'C05', 'C06', 'C07', 'C08', 'C09', 'C10', 'C11', 'C12', 'C13', 'C14', 'C15', 'C16', 'true_color', 'natural_color']
### Custom User Products
*true_color_night

### Non-standard Satpy Products
*cimss_cloud_type
...
*water_vapors2

### Standard Available Geo2Grid Products
C01
...
C16
airmass
ash
dust
fog
natural_color
night_microphysics
true_color
```