### PR TITLE
Fix various AVHRR and CLAVRx data handling bugs

### DIFF
--- a/etc/resampling.yaml
+++ b/etc/resampling.yaml
@@ -6,6 +6,7 @@ resampling:
     area_type: area
     # Default 'resampler' will be determined at runtime based on target area
     default_target: MAX
+
   default_clavrx_all_products:
     reader: clavrx
     area_type: swath
@@ -31,6 +32,38 @@ resampling:
       weight_delta_max: 40.0
       weight_distance_max: 1.0
       maximum_weight_mode: true
+
+  avhrr_clavrx_all_products:
+    reader: clavrx
+    area_type: swath
+    sensor: avhrr
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 1.0
+      rows_per_scan: 0
+  avhrr_clavrx_cloud_phase:
+    name: cloud_phase
+    reader: clavrx
+    area_type: swath
+    sensor: avhrr
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 1.0
+      maximum_weight_mode: true
+      rows_per_scan: 0
+  avhrr_clavrx_cloud_type:
+    name: cloud_type
+    reader: clavrx
+    area_type: swath
+    sensor: avhrr
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 1.0
+      maximum_weight_mode: true
+      rows_per_scan: 0
   default_amsr2:
     area_type: swath
     sensor: amsr2

--- a/polar2grid/filters/_utils.py
+++ b/polar2grid/filters/_utils.py
@@ -75,6 +75,13 @@ def _compute_boundary_from_whole_swath(swath_def: SwathDefinition):
     min_lat = np.nanmin(lats)
     max_lat = np.nanmax(lats)
     min_lon, max_lon, min_lat, max_lat = da.compute(min_lon, max_lon, min_lat, max_lat)
+    x_passes_antimeridian = (max_lon - min_lon) > 355
+    epsilon = 0.1
+    y_is_pole = (max_lat >= 90 - epsilon) or (min_lat <= -90 + epsilon)
+    if x_passes_antimeridian and not y_is_pole:
+        wrapped_lons = lons % 360
+        min_lon, max_lon = da.compute(np.nanmin(wrapped_lons), np.nanmax(wrapped_lons))
+        max_lon -= 360
     sides = (
         ([min_lon, max_lon], [max_lat, max_lat]),  # top
         ([max_lon, max_lon], [max_lat, min_lat]),  # right

--- a/polar2grid/filters/_utils.py
+++ b/polar2grid/filters/_utils.py
@@ -24,6 +24,9 @@
 
 import logging
 
+import dask.array as da
+import numpy as np
+
 try:
     # Python 3.9+
     from functools import cache
@@ -32,10 +35,6 @@ except ImportError:
 
 from typing import Union
 
-import dask.array as da
-import numpy as np
-import pyresample
-from packaging.version import Version, parse
 from pyresample.boundary import AreaBoundary, AreaDefBoundary, Boundary
 from pyresample.geometry import (
     AreaDefinition,
@@ -45,40 +44,44 @@ from pyresample.geometry import (
 from pyresample.spherical import SphPolygon
 
 logger = logging.getLogger(__name__)
-FIXED_PR = parse(pyresample.__version__) >= Version("1.22.1")
 
 PRGeometry = Union[SwathDefinition, AreaDefinition]
 
 
 def boundary_for_area(area_def: PRGeometry) -> Boundary:
     """Create Boundary object representing the provided area."""
-    if not FIXED_PR and isinstance(area_def, SwathDefinition):
-        # TODO: Persist lon/lats if requested
-        lons, lats = area_def.get_bbox_lonlats()
-        freq = int(area_def.shape[0] * 0.05)
-        if hasattr(lons[0], "compute") and da is not None:
-            lons, lats = da.compute(lons, lats)
-        lons = [lon_side.astype(np.float64) for lon_side in lons]
-        lats = [lat_side.astype(np.float64) for lat_side in lats]
-        # compare the first two pixels in the right column
-        lat_is_increasing = lats[1][0] < lats[1][1]
-        # compare the first two pixels in the "top" column
-        lon_is_increasing = lons[0][0] < lons[0][1]
-        is_ccw = (lon_is_increasing and lat_is_increasing) or (not lon_is_increasing and not lat_is_increasing)
-        if is_ccw:
-            # going counter-clockwise
-            # swap the side order and the order of the values in each side
-            # to make it clockwise
-            lons = [lon[::-1] for lon in lons[::-1]]
-            lats = [lat[::-1] for lat in lats[::-1]]
-        adp = AreaBoundary(*zip(lons, lats))
-        adp.decimate(freq)
-    elif getattr(area_def, "is_geostationary", False):
+    if getattr(area_def, "is_geostationary", False):
         adp = Boundary(*get_geostationary_bounding_box(area_def, nb_points=100))
     else:
         freq_fraction = 0.05 if isinstance(area_def, SwathDefinition) else 0.30
-        adp = AreaDefBoundary(area_def, frequency=int(area_def.shape[0] * freq_fraction))
+        try:
+            adp = AreaDefBoundary(area_def, frequency=int(area_def.shape[0] * freq_fraction))
+        except ValueError:
+            if not isinstance(area_def, SwathDefinition):
+                logger.error("Unable to generate bounding geolocation polygon")
+                raise
+
+            logger.warning(
+                "Geolocation data contains invalid bounding values. Computing entire array to get bounds instead."
+            )
+            adp = _compute_boundary_from_whole_swath(area_def)
     return adp
+
+
+def _compute_boundary_from_whole_swath(swath_def: SwathDefinition):
+    lons, lats = swath_def.get_lonlats()
+    min_lon = np.nanmin(lons)
+    max_lon = np.nanmax(lons)
+    min_lat = np.nanmin(lats)
+    max_lat = np.nanmax(lats)
+    min_lon, max_lon, min_lat, max_lat = da.compute(min_lon, max_lon, min_lat, max_lat)
+    sides = (
+        ([min_lon, max_lon], [max_lat, max_lat]),  # top
+        ([max_lon, max_lon], [max_lat, min_lat]),  # right
+        ([max_lon, min_lon], [min_lat, min_lat]),  # bot
+        ([min_lon, max_lon], [min_lat, max_lat]),  # left
+    )
+    return AreaBoundary(*sides)
 
 
 @cache

--- a/polar2grid/filters/day_night.py
+++ b/polar2grid/filters/day_night.py
@@ -158,7 +158,7 @@ class DayCoverageFilter(SunlightCoverageFilter):
 
 
 class NightCoverageFilter(SunlightCoverageFilter):
-    """Remove certain products when there is not enough day data."""
+    """Remove certain products when there is not enough night data."""
 
     FILTER_MSG = "Unloading '{}' because there is not enough night data."
 

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -52,6 +52,7 @@ from polar2grid.readers._base import ReaderProxyBase
 from polar2grid.resample import resample_scene
 from polar2grid.utils.config import add_polar2grid_config_paths
 from polar2grid.utils.dynamic_imports import get_reader_attr
+from polar2grid.utils.legacy_compat import get_sensor_alias
 
 LOG = logging.getLogger(__name__)
 
@@ -90,11 +91,6 @@ _PLATFORM_ALIASES = {
 }
 
 
-_SENSOR_ALIASES = {
-    "avhrr-3": "avhrr",
-}
-
-
 def _get_platform_name_alias(satpy_platform_name):
     return _PLATFORM_ALIASES.get(satpy_platform_name.lower(), satpy_platform_name)
 
@@ -108,21 +104,12 @@ def _overwrite_platform_name_with_aliases(scn):
         data_arr.attrs["platform_name"] = pname
 
 
-def _get_sensor_alias(satpy_sensor):
-    if not isinstance(satpy_sensor, set):
-        satpy_sensor = {satpy_sensor}
-    new_sensor = {_SENSOR_ALIASES.get(sname, sname) for sname in satpy_sensor}
-    if len(new_sensor) == 1:
-        return new_sensor.pop()
-    return new_sensor
-
-
 def _overwrite_sensor_with_aliases(scn):
     """Change 'sensor' for every DataArray to Polar2Grid expectations."""
     for data_arr in scn:
         if "sensor" not in data_arr.attrs:
             continue
-        pname = _get_sensor_alias(data_arr.attrs["sensor"])
+        pname = get_sensor_alias(data_arr.attrs["sensor"])
         data_arr.attrs["sensor"] = pname
 
 

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -80,21 +80,19 @@ if ADVERTISED_DATASETS == "all":
 elif ADVERTISED_DATASETS:
     ADVERTISED_DATASETS = ADVERTISED_DATASETS.split(" ")
 else:
-    ADVERTISED_DATASETS = set(
-        [
-            "cloud_type",
-            "cld_temp_acha",
-            "cld_height_acha",
-            "cloud_phase",
-            "cld_opd_dcomp",
-            "cld_opd_nlcomp",
-            "cld_reff_dcomp",
-            "cld_reff_nlcomp",
-            "cld_emiss_acha",
-            "refl_lunar_dnb_nom",
-            "rain_rate",
-        ]
-    )
+    ADVERTISED_DATASETS = {
+        "cloud_type",
+        "cld_temp_acha",
+        "cld_height_acha",
+        "cloud_phase",
+        "cld_opd_dcomp",
+        "cld_opd_nlcomp",
+        "cld_reff_dcomp",
+        "cld_reff_nlcomp",
+        "cld_emiss_acha",
+        "refl_lunar_dnb_nom",
+        "rain_rate",
+    }
 
 DEFAULT_DATASETS = [
     "cloud_type",

--- a/polar2grid/resample/resample_decisions.py
+++ b/polar2grid/resample/resample_decisions.py
@@ -31,6 +31,8 @@ from satpy._config import config_search_paths
 from satpy.utils import recursive_dict_update
 from satpy.writers import DecisionTree
 
+from polar2grid.utils.legacy_compat import get_sensor_alias
+
 logger = logging.getLogger(__name__)
 
 
@@ -43,11 +45,11 @@ class ResamplerDecisionTree(DecisionTree):
             "match_keys",
             (
                 "name",
+                "reader",
                 "platform_name",
                 "sensor",
-                "standard_name",
                 "area_type",
-                "reader",
+                "standard_name",
                 "units",
             ),
         )
@@ -88,6 +90,7 @@ class ResamplerDecisionTree(DecisionTree):
     def find_match(self, **query_dict):
         """Find a match."""
         query_dict["area_type"] = "swath" if isinstance(query_dict["area"], SwathDefinition) else "area"
+        query_dict["sensor"] = get_sensor_alias(query_dict.get("sensor"))
 
         try:
             return super().find_match(**query_dict)

--- a/polar2grid/tests/_avhrr_fixtures.py
+++ b/polar2grid/tests/_avhrr_fixtures.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Copyright (C) 2022 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Test fixtures representing AVHRR swath data."""
+from __future__ import annotations
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyresample import SwathDefinition
+from satpy import Scene
+from satpy.tests.utils import make_dataid
+
+from ._fixture_utils import START_TIME, _TestingScene, generate_lonlat_data
+
+AVHRR_SHAPE = (2361, 2048)
+AVHRR_CHUNKS = AVHRR_SHAPE
+
+AVHRR_IDS = [
+    make_dataid(name="1", wavelength=(0.58, 0.63, 0.68), resolution=1050, calibration="reflectance"),
+]
+
+
+@pytest.fixture(scope="session")
+def avhrr_l1b_swath_def() -> SwathDefinition:
+    lons, lats = generate_lonlat_data(AVHRR_SHAPE)
+    lons_data_arr = xr.DataArray(
+        da.from_array(lons, chunks=AVHRR_CHUNKS),
+        dims=("y", "x"),
+        attrs={
+            "platform_name": "noaa19",
+            "sensor": "avhrr-3",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 1050,
+            "reader": "avhrr_l1b_aapp",
+        },
+    )
+    lats_data_arr = xr.DataArray(
+        da.from_array(lats, chunks=AVHRR_CHUNKS),
+        dims=("y", "x"),
+        attrs={
+            "platform_name": "noaa19",
+            "sensor": "avhrr-3",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 1050,
+            "reader": "avhrr_l1b_aapp",
+        },
+    )
+    return SwathDefinition(lons_data_arr, lats_data_arr)
+
+
+@pytest.fixture
+def avhrr_l1b_1_data_array(avhrr_l1b_swath_def) -> xr.DataArray:
+    return xr.DataArray(
+        da.zeros(AVHRR_SHAPE, dtype=np.float32),
+        dims=("y", "x"),
+        attrs={
+            "area": avhrr_l1b_swath_def,
+            "platform_name": "noaa19",
+            "sensor": "avhrr-3",
+            "name": "1",
+            "start_time": START_TIME,
+            "end_time": START_TIME,
+            "resolution": 1050,
+            "reader": "avhrr_l1b_aapp",
+            "calibration": "reflectance",
+            "standard_name": "toa_bidirectional_reflectance",
+            "units": "%",
+        },
+    )
+
+
+@pytest.fixture
+def avhrr_l1b_1_scene(avhrr_l1b_1_data_array) -> Scene:
+    scn = _TestingScene(
+        reader="avhrr_l1b_aapp",
+        filenames=["/fake/filename"],
+        data_array_dict={
+            AVHRR_IDS[0]: avhrr_l1b_1_data_array.copy(),
+        },
+        all_dataset_ids=AVHRR_IDS,
+        available_dataset_ids=AVHRR_IDS[:1],
+    )
+    return scn

--- a/polar2grid/tests/_fixture_utils.py
+++ b/polar2grid/tests/_fixture_utils.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import numpy as np
+from numpy.typing import DTypeLike, NDArray
 from satpy import DatasetDict, Scene
 from satpy.readers.yaml_reader import FileYAMLReader
 
@@ -53,6 +55,7 @@ class _FakeReader(FileYAMLReader):
         return {
             "viirs_sdr": {"viirs"},
             "abi_l1b": {"abi"},
+            "avhrr_l1b_aapp": {"avhrr-3"},
         }[self._name]
 
     @property
@@ -91,3 +94,11 @@ class _TestingScene(Scene):
         return {
             reader: _FakeReader(reader, self._forced_products, self._forced_all_ids, self._forced_available_ids),
         }
+
+
+def generate_lonlat_data(shape: tuple[int, int], dtype: DTypeLike = np.float32) -> tuple[NDArray, NDArray]:
+    lat = np.repeat(np.linspace(25.0, 55.0, shape[0])[:, None], shape[1], 1)
+    lat *= np.linspace(0.9, 1.1, shape[1])
+    lon = np.repeat(np.linspace(-45.0, -65.0, shape[1])[None, :], shape[0], 0)
+    lon *= np.linspace(0.9, 1.1, shape[0])[:, None]
+    return lon.astype(dtype), lat.astype(dtype)

--- a/polar2grid/tests/_viirs_fixtures.py
+++ b/polar2grid/tests/_viirs_fixtures.py
@@ -27,12 +27,11 @@ import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
-from numpy.typing import DTypeLike, NDArray
 from pyresample import SwathDefinition
 from satpy import Scene
 from satpy.tests.utils import make_dataid
 
-from ._fixture_utils import START_TIME, _TestingScene
+from ._fixture_utils import START_TIME, _TestingScene, generate_lonlat_data
 
 VIIRS_I_CHUNKS = (32 * 3, 6400)
 VIIRS_M_CHUNKS = (16 * 3, 3200)
@@ -142,17 +141,9 @@ VIIRS_ALL_IDS = (
 )
 
 
-def _generate_lonlat_data(shape: tuple[int, int], dtype: DTypeLike = np.float32) -> tuple[NDArray, NDArray]:
-    lat = np.repeat(np.linspace(25.0, 55.0, shape[0])[:, None], shape[1], 1)
-    lat *= np.linspace(0.9, 1.1, shape[1])
-    lon = np.repeat(np.linspace(-45.0, -65.0, shape[1])[None, :], shape[0], 0)
-    lon *= np.linspace(0.9, 1.1, shape[0])[:, None]
-    return lon.astype(dtype), lat.astype(dtype)
-
-
 @pytest.fixture(scope="session")
 def viirs_sdr_i_swath_def() -> SwathDefinition:
-    lons, lats = _generate_lonlat_data((1536, 6400))
+    lons, lats = generate_lonlat_data((1536, 6400))
     lons_data_arr = xr.DataArray(
         da.from_array(lons, chunks=VIIRS_I_CHUNKS),
         dims=("y", "x"),
@@ -184,7 +175,7 @@ def viirs_sdr_i_swath_def() -> SwathDefinition:
 
 @pytest.fixture(scope="session")
 def viirs_sdr_m_swath_def() -> SwathDefinition:
-    lons, lats = _generate_lonlat_data((768, 3200))
+    lons, lats = generate_lonlat_data((768, 3200))
     lons_data_arr = xr.DataArray(
         da.from_array(lons, chunks=VIIRS_M_CHUNKS),
         dims=("y", "x"),
@@ -216,7 +207,7 @@ def viirs_sdr_m_swath_def() -> SwathDefinition:
 
 @pytest.fixture(scope="session")
 def viirs_sdr_dnb_swath_def() -> SwathDefinition:
-    lons, lats = _generate_lonlat_data((768, 4064))
+    lons, lats = generate_lonlat_data((768, 4064))
     lons_data_arr = xr.DataArray(
         da.from_array(lons, chunks=VIIRS_DNB_CHUNKS),
         dims=("y", "x"),

--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -32,7 +32,11 @@ import pytest
 PKG_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 root_logger = logging.getLogger()
 
-pytest_plugins = ["polar2grid.tests._abi_fixtures", "polar2grid.tests._viirs_fixtures"]
+pytest_plugins = [
+    "polar2grid.tests._abi_fixtures",
+    "polar2grid.tests._viirs_fixtures",
+    "polar2grid.tests._avhrr_fixtures",
+]
 
 
 def pytest_configure(config):

--- a/polar2grid/tests/test_filters/__init__.py
+++ b/polar2grid/tests/test_filters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for polar2grid.filters components."""

--- a/polar2grid/tests/test_filters/test_utils.py
+++ b/polar2grid/tests/test_filters/test_utils.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Copyright (C) 2022 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Tests for filtering utilities."""
+
+import dask
+import dask.array as da
+import numpy as np
+from pyresample import SwathDefinition
+from pyresample.boundary import AreaBoundary
+from satpy.tests.utils import CustomScheduler
+
+from polar2grid.filters._utils import boundary_for_area
+
+from .._fixture_utils import generate_lonlat_data
+
+
+def _swath_def_nan_rows() -> SwathDefinition:
+    lons, lats = generate_lonlat_data((200, 100))
+    lons[:9, :] = np.nan
+    lats[:9, :] = np.nan
+    lons_da = da.from_array(lons)
+    lats_da = da.from_array(lats)
+    swath_def = SwathDefinition(
+        lons_da,
+        lats_da,
+    )
+    return swath_def
+
+
+def _exp_boundary_nan_rows():
+    exp_boundary = AreaBoundary(
+        ([-71.5, -40.907036], [60.5, 60.5]),
+        ([-40.907036, -40.907036], [60.5, 23.721106]),
+        ([-40.907036, -71.5], [23.721106, 23.721106]),
+        ([-71.5, -40.907036], [23.721106, 60.5]),
+    )
+    return exp_boundary
+
+
+def test_boundary_for_area():
+    geom_obj = _swath_def_nan_rows()
+    exp_boundary = _exp_boundary_nan_rows()
+
+    with dask.config.set(scheduler=CustomScheduler(1)):
+        boundary = boundary_for_area(geom_obj)
+
+    np.testing.assert_allclose(boundary.contour()[0], exp_boundary.contour()[0])
+    np.testing.assert_allclose(boundary.contour()[1], exp_boundary.contour()[1])

--- a/polar2grid/tests/test_resample/test_resample_scene.py
+++ b/polar2grid/tests/test_resample/test_resample_scene.py
@@ -167,6 +167,19 @@ from polar2grid.resample._resample_scene import resample_scene
             {},
             {},
         ),
+        (
+            lazy_fixture("avhrr_l1b_1_scene"),
+            ["wgs84_fit"],
+            lazy_fixture("builtin_grids_yaml"),
+            None,
+            ["1"],
+            1,
+            True,
+            DaskEWAResampler,
+            0,
+            {},
+            {"weight_delta_max": 10.0, "weight_distance_max": 1.0, "rows_per_scan": 0},
+        ),
     ],
 )
 def test_resample_single_result_per_grid(

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -244,3 +244,17 @@ class AliasHandler:
 
         available_satpy_names = sorted(set(available_satpy_names))
         return available_p2g_names, available_custom_names, available_satpy_names
+
+
+_SENSOR_ALIASES = {
+    "avhrr-3": "avhrr",
+}
+
+
+def get_sensor_alias(satpy_sensor):
+    if not isinstance(satpy_sensor, set):
+        satpy_sensor = {satpy_sensor}
+    new_sensor = {_SENSOR_ALIASES.get(sname, sname) for sname in satpy_sensor}
+    if len(new_sensor) == 1:
+        return new_sensor.pop()
+    return new_sensor


### PR DESCRIPTION
Fixes include:

1. Fixing the handling of CLAVRx's rows of NaNs in geolocation data.
2. Fix AVHRR resampling configuration being used incorrectly. Note though that the 40:1 used for CLAVRx and 10:1 used for AVHRR L1b both produce holes on the edges of swaths in some data cases.
3. Other code cleanup and typos

Should address some of the issues in #520, and completely close #517.