### PR TITLE
Fix MERSI-2 resampling config and remove natural_color as default product

### DIFF
--- a/etc/resampling.yaml
+++ b/etc/resampling.yaml
@@ -257,3 +257,11 @@ resampling:
     kwargs:
       weight_delta_max: 40.0
       weight_distance_max: 1.0
+
+  default_mersi2_l1b:
+    area_type: swath
+    reader: mersi2_l1b
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 1.0

--- a/polar2grid/readers/mersi2_l1b.py
+++ b/polar2grid/readers/mersi2_l1b.py
@@ -108,7 +108,7 @@ from ._base import ReaderProxyBase
 
 ALL_BANDS = [str(x) for x in range(1, 26)]
 ALL_ANGLES = ["solar_zenith_angle", "solar_azimuth_angle", "sensor_zenith_angle", "sensor_azimuth_angle"]
-ALL_COMPS = ["true_color", "false_color", "natural_color"]
+ALL_COMPS = ["true_color", "false_color"]
 
 DEFAULT_PRODUCTS = ALL_BANDS + ALL_COMPS
 


### PR DESCRIPTION
Addresses some of the issues in #534. Specifically there was no resampling config for the MERSI-2 sensor and `natural_color` was listed as a default product when it should only be an "available" product.