### PR TITLE
Fix day/night filtering for clavrx products

### DIFF
--- a/polar2grid/filters/_base.py
+++ b/polar2grid/filters/_base.py
@@ -36,8 +36,9 @@ class BaseFilter:
     This class uses a series of metadata comparisons to check if a product
     should be checked for filtering. If any of the product metadata criteria
     match then filtering checks are continued. Otherwise, the product is
-    ignored. If the criteria is not provided, then all products will be
-    checked.
+    ignored. If the criteria is not provided or is ``None`` or is empty then
+    no products will be checked. If the criteria is passed as ``True`` then
+    all products will be checked.
 
     By default, no extra filtering is performed and only the metadata criteria
     is used. This means that if no criteria is provided, this class will
@@ -49,13 +50,16 @@ class BaseFilter:
 
     def __init__(self, product_filter_criteria: dict = None):
         """Initialize thresholds and default search criteria."""
-        self._filter_criteria = product_filter_criteria or {}
+        self._filter_criteria = product_filter_criteria
 
     def _matches_criteria(self, data_arr: DataArray):
         attrs = data_arr.attrs
-        if not self._filter_criteria:
-            # if not criteria was provided then filtering should be performed
+        if self._filter_criteria is True:
+            # check all products
             return True
+        if not self._filter_criteria:
+            # if no criteria was provided then no products will be checked
+            return False
 
         for filter_key, filter_list in self._filter_criteria.items():
             if attrs.get(filter_key) in filter_list:

--- a/polar2grid/filters/day_night.py
+++ b/polar2grid/filters/day_night.py
@@ -147,10 +147,6 @@ class DayCoverageFilter(SunlightCoverageFilter):
 
     def __init__(self, product_filter_criteria: dict = None, sza_threshold: float = 100.0, day_fraction: float = 0.1):
         """Initialize thresholds and default search criteria."""
-        product_filter_criteria = product_filter_criteria or {}
-        matching_standard_names = ["toa_bidirectional_reflectance", "true_color", "natural_color", "false_color"]
-        product_filter_criteria.setdefault("standard_name", matching_standard_names)
-
         super().__init__(product_filter_criteria, sza_threshold=sza_threshold, fraction=day_fraction)
 
     def _should_be_filtered(self, sunlight_coverage):
@@ -164,10 +160,6 @@ class NightCoverageFilter(SunlightCoverageFilter):
 
     def __init__(self, product_filter_criteria: dict = None, sza_threshold: float = 100.0, night_fraction: float = 0.1):
         """Initialize thresholds and default search criteria."""
-        product_filter_criteria = product_filter_criteria or {}
-        matching_standard_names = ["temperature_difference"]
-        product_filter_criteria.setdefault("standard_name", matching_standard_names)
-
         super().__init__(product_filter_criteria, sza_threshold=sza_threshold, fraction=night_fraction)
 
     def _should_be_filtered(self, sunlight_coverage):

--- a/polar2grid/filters/resample_coverage.py
+++ b/polar2grid/filters/resample_coverage.py
@@ -53,11 +53,16 @@ def _get_intersection_coverage(source_polygon: SphPolygon, target_polygon: SphPo
 
 
 class ResampleCoverageFilter(BaseFilter):
-    """Remove any DataArrays that would not have any results if resampled to the target area."""
+    """Remove any DataArrays that would not have any results if resampled to the target area.
+
+    This filter defaults to checking all products. Pass ``product_filter_critera=None`` to
+    disable checking for all products. See :class:`BaseFilter` for other options.
+
+    """
 
     def __init__(
         self,
-        product_filter_criteria: dict = None,
+        product_filter_criteria: dict = True,
         target_area: PRGeometry = None,
         coverage_fraction: float = None,
     ):

--- a/polar2grid/readers/clavrx.py
+++ b/polar2grid/readers/clavrx.py
@@ -110,13 +110,18 @@ DEFAULT_DATASETS = [
 
 FILTERS = {
     "day_only": {
-        "standard_name": [
-            "toa_bidirectional_reflectance",
-            "effective_radius_of_cloud_condensed_water_particles_at_cloud_top",
-            "atmosphere_optical_thickness_due_to_cloud",
-        ]
+        "name": [
+            "cld_opd_dcomp",
+            "cld_reff_dcomp",
+        ],
     },
-    "night_only": {"standard_name": ["refl_lunar_dnb_nom"]},
+    "night_only": {
+        "name": [
+            "cld_opd_nlcomp",
+            "cld_reff_nlcomp",
+            "refl_lunar_dnb_nom",
+        ],
+    },
 }
 
 

--- a/polar2grid/tests/test_filters/test_day_night.py
+++ b/polar2grid/tests/test_filters/test_day_night.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Copyright (C) 2022 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Tests day/night filtering."""
+
+import pytest
+from satpy import Scene
+
+from polar2grid.filters.day_night import DayCoverageFilter, NightCoverageFilter
+
+
+@pytest.mark.parametrize(
+    "filter_cls",
+    [DayCoverageFilter, NightCoverageFilter],
+)
+@pytest.mark.parametrize(
+    "criteria",
+    ["default", None, {}],
+)
+def test_daynight_filter_no_filter_check_cases(filter_cls, criteria, viirs_sdr_i01_data_array):
+    scn = Scene()
+    scn["I01"] = viirs_sdr_i01_data_array
+
+    if criteria == "default":
+        filter = filter_cls()
+    else:
+        filter = filter_cls(criteria)
+    new_scn = filter.filter_scene(scn)
+    assert new_scn is not None
+    assert new_scn is not scn
+    assert "I01" in new_scn
+
+
+@pytest.mark.parametrize(
+    ("filter_cls", "kwargs"),
+    [
+        (DayCoverageFilter, {"day_fraction": 0.95}),
+        (NightCoverageFilter, {"night_fraction": 0.5}),
+    ],
+)
+def test_daynight_filter_filter_cases(filter_cls, kwargs, viirs_sdr_i01_data_array):
+    scn = Scene()
+    scn["I01"] = viirs_sdr_i01_data_array  # calculates to ~0.8 day
+
+    criteria = {"standard_name": ["toa_bidirectional_reflectance"]}
+    filter = filter_cls(criteria, **kwargs)
+    new_scn = filter.filter_scene(scn)
+    assert new_scn is None  # all filtered
+    assert "I01" in scn


### PR DESCRIPTION
Closes the 3rd task on #520. The bottom line is that the reader was configured to check products with the "toa_bidirectional_reflectance" standard name and the standard names for `opd` and `reff`...but that includes both day and night versions of those products. This PR changes the filtering to be based on exact name for these products.

In addition to fixing this filter, my debugging revealed that I don't like how the default filtering is used. There were defaults for the day/night filtering so even if the reader said *not* to filter anything they would still check them for true_color/false_color/reflectances. It was a waste of time for readers that don't have filtering configured.