### PR TITLE
Deprecate --colorbar-vertical in add_coastlines

### DIFF
--- a/build_environment.yml
+++ b/build_environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - pillow
   - pip
   - pooch
-  - pycoast>=1.5.0
+  - pycoast>=1.6.0
   - pydecorate>=0.3.3
   - pyhdf
   - pykdtree

--- a/polar2grid/add_coastlines.py
+++ b/polar2grid/add_coastlines.py
@@ -51,21 +51,6 @@ LOG = logging.getLogger(__name__)
 PYCOAST_DIR = os.environ.get("GSHHS_DATA_ROOT")
 
 
-def _convert_table_to_cmap_or_default_bw(band_dtype, band_ct, band_count):
-    max_val = np.iinfo(band_dtype).max
-    # if we have an alpha band then include the entire colormap
-    # otherwise assume it is using 0 as a fill value
-    start_idx = 1 if band_count == 1 else 0
-    if band_ct is None:
-        # NOTE: the comma is needed to make this a tuple
-        color_iter = ((idx / float(max_val), (int(idx / float(max_val)),) * 3 + (1.0,)) for idx in range(max_val))
-    else:
-        color_iter = ((idx / float(max_val), color) for idx, color in sorted(band_ct.items())[start_idx:])
-        color_iter = ((idx, tuple(x / float(max_val) for x in color)) for idx, color in color_iter)
-    cmap = Colormap(*color_iter)
-    return cmap
-
-
 def _get_rio_colormap(rio_ds, bidx):
     try:
         return rio_ds.colormap(bidx)
@@ -120,28 +105,24 @@ def _vmin_vmax_from_scale_offset(scale: float, offset: float, dtype_min: int, dt
     return vmin, vmax
 
 
-def _apply_decorator_alignment(dc, align, is_vertical):
-    default_align = "left" if is_vertical else "bottom"
-    if align is None:
-        align = default_align
+def _apply_decorator_alignment(dc, align):
     if align == "top":
         dc.align_top()
+        dc.write_horizontally()
     elif align == "bottom":
         dc.align_bottom()
+        dc.write_horizontally()
     elif align == "left":
         dc.align_left()
+        dc.write_vertically()
     elif align == "right":
         dc.align_right()
-
-
-def _add_colorbar_to_image(img, font, tick_color, align, vertical, **kwargs):
-    dc = DecoratorAGG(img)
-    _apply_decorator_alignment(dc, align, vertical)
-    if vertical:
         dc.write_vertically()
-    else:
-        dc.write_horizontally()
 
+
+def _add_colorbar_to_image(img, font, tick_color, align, **kwargs):
+    dc = DecoratorAGG(img)
+    _apply_decorator_alignment(dc, align)
     dc.add_scale(
         font=font,
         line=tick_color,
@@ -282,16 +263,10 @@ def _add_colorbar_arguments(parser: argparse.ArgumentParser) -> None:
     group.add_argument(
         "--colorbar-align",
         choices=["left", "top", "right", "bottom"],
-        default=None,
-        help="Which direction to align colorbar (see --colorbar-vertical)",
+        default="bottom",
+        help="Which side of the image to place the colorbar",
     )
-    group.add_argument("--colorbar-vertical", action="store_true", help="Position the colorbar vertically")
-    group.add_argument(
-        "--colorbar-no-ticks",
-        dest="colorbar_ticks",
-        action="store_false",
-        help="Don't include ticks and tick labels on colorbar",
-    )
+    group.add_argument("--colorbar-vertical", action="store_true", help="DEPRECATED")
     group.add_argument(
         "--colorbar-min",
         type=float,
@@ -477,7 +452,10 @@ def _args_to_colorbar_kwargs(args):
     font = Font(font_color, font_path, size=args.colorbar_text_size)
 
     if args.colorbar_width is None or args.colorbar_height is None:
-        LOG.warning("'--colorbar-width' or '--colorbar-height' were " "not specified. Forcing '--colorbar-extend'.")
+        if args.colorbar_width is not None or args.colorbar_height is not None:
+            LOG.warning(
+                "'--colorbar-width' and '--colorbar-height' were not both specified. " "Forcing '--colorbar-extend'."
+            )
         args.colorbar_extend = True
 
     colorbar_kwargs = {
@@ -486,7 +464,6 @@ def _args_to_colorbar_kwargs(args):
         "cmin": args.colorbar_min,
         "cmax": args.colorbar_max,
         "align": args.colorbar_align,
-        "vertical": args.colorbar_vertical,
         "extend": args.colorbar_extend,
         "tick_marks": args.colorbar_tick_marks,
         "title": args.colorbar_title,
@@ -547,6 +524,23 @@ def _get_colormap_object(input_tiff, num_bands, cmin, cmax):
         cmap = Colormap.from_file(colormap_csv)
     vmin, vmax = _get_colorbar_vmin_vmax(cmin, cmax, metadata, input_dtype)
     cmap = cmap.set_range(vmin, vmax, inplace=False)
+    return cmap
+
+
+def _convert_table_to_cmap_or_default_bw(band_dtype, band_ct, band_count):
+    max_val = np.iinfo(band_dtype).max
+    # if we have an alpha band then include the entire colormap
+    # otherwise assume it is using 0 as a fill value
+    start_idx = 1 if band_count == 1 else 0
+    if band_ct is None:
+        # grayscale colormap
+        # NOTE: the comma is needed to make this a tuple
+        color_iter = ((idx / float(max_val), (idx / max_val,) * 3 + (1.0,)) for idx in range(max_val))
+        color_iter = list(color_iter)
+    else:
+        color_iter = ((idx / float(max_val), color) for idx, color in sorted(band_ct.items())[start_idx:])
+        color_iter = ((idx, tuple(x / float(max_val) for x in color)) for idx, color in color_iter)
+    cmap = Colormap(*color_iter)
     return cmap
 
 

--- a/polar2grid/add_coastlines.py
+++ b/polar2grid/add_coastlines.py
@@ -533,9 +533,10 @@ def _convert_table_to_cmap_or_default_bw(band_dtype, band_ct, band_count):
     # otherwise assume it is using 0 as a fill value
     start_idx = 1 if band_count == 1 else 0
     if band_ct is None:
-        # grayscale colormap
-        # NOTE: the comma is needed to make this a tuple
-        color_iter = ((idx / float(max_val), (idx / max_val,) * 3 + (1.0,)) for idx in range(max_val))
+        # all black colormap
+        # don't assume anything about the colors or scaling of the image if the
+        # user didn't provide enough information
+        color_iter = ((idx / float(max_val), (0.0, 0.0, 0.0, 1.0)) for idx in range(max_val))
         color_iter = list(color_iter)
     else:
         color_iter = ((idx / float(max_val), color) for idx, color in sorted(band_ct.items())[start_idx:])

--- a/polar2grid/tests/test_add_coastlines.py
+++ b/polar2grid/tests/test_add_coastlines.py
@@ -185,9 +185,8 @@ def _check_used_colormap(passed_cmap, has_colors, include_cmap_tag, include_scal
     assert cmax == exp_cmax
 
     if not has_colors:
-        # no colormap, grayscale default colormap
-        np.testing.assert_allclose(passed_cmap.colors[:, 0], passed_cmap.colors[:, 1])
-        np.testing.assert_allclose(passed_cmap.colors[:, 0], passed_cmap.colors[:, 2])
+        # no colormap, all black default colormap
+        np.testing.assert_allclose(passed_cmap.colors[:, :3], 0)
 
 
 def _check_exp_image_colors(image_arr, colormap, color_idx, has_colors):

--- a/polar2grid/tests/test_add_coastlines.py
+++ b/polar2grid/tests/test_add_coastlines.py
@@ -185,8 +185,9 @@ def _check_used_colormap(passed_cmap, has_colors, include_cmap_tag, include_scal
     assert cmax == exp_cmax
 
     if not has_colors:
-        # no colormap, pure black colorbar
-        np.testing.assert_allclose(passed_cmap.colors[:, :3], 0)
+        # no colormap, grayscale default colormap
+        np.testing.assert_allclose(passed_cmap.colors[:, 0], passed_cmap.colors[:, 1])
+        np.testing.assert_allclose(passed_cmap.colors[:, 0], passed_cmap.colors[:, 2])
 
 
 def _check_exp_image_colors(image_arr, colormap, color_idx, has_colors):


### PR DESCRIPTION
Closes #439 

As described in the related issue, there is no need for --colorbar-vertical to exist as it can be inferred from the position of the colorbar (top, bottom, left, right). This PR removes the usage of it but doesn't remove the flag so it doesn't completely break people's scripts.

This PR also re-enables the default colorbar to be a grayscale colormap. This could be a problem if users think their non-linearly scaled data should have a linear colormap, but I think that's up to the user. @kathys what do you think: If I did a square root enhancement on VIIRS I01 and then ran add_coastlines.sh I'd be get a black->white colormap with the tick labels being 0 to 255.