### PR TITLE
Fix extra config paths being handled in the wrong order

### DIFF
--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -423,7 +423,7 @@ def _prepare_initial_logging(arg_parser, glue_name: str) -> bool:
 def _add_extra_config_paths(extra_paths: list[str]):
     config_path = satpy.config.get("config_path")
     LOG.info(f"Adding additional configuration paths: {extra_paths}")
-    satpy.config.set(config_path=extra_paths + config_path)
+    satpy.config.set(config_path=config_path + extra_paths)
 
 
 def _check_valid_config_paths(extra_config_paths: Iterable):


### PR DESCRIPTION
Closes #546 

This is a simple fix for the problem described in the related issue. Basically the user custom path was being applied before the polar2grid builtins were applied rendering them useless in any cases where the configurations matched.