### PR TITLE
Update --filter-day/night-products flags to allow for "false"

### DIFF
--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -413,7 +413,7 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
     group_1.add_argument(
         "--filter-day-products",
         nargs="?",
-        type=float,
+        type=float_or_false,
         default=filter_dn_products,
         metavar="fraction_of_day",
         help="Don't produce products that require "
@@ -427,7 +427,7 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
     group_1.add_argument(
         "--filter-night-products",
         nargs="?",
-        type=float,
+        type=float_or_false,
         default=filter_dn_products,
         metavar="fraction_of_night",
         help="Don't produce products that require "
@@ -460,6 +460,12 @@ def add_scene_argument_groups(parser, is_polar2grid=False):
         help=argparse.SUPPRESS,
     )
     return (group_1,)
+
+
+def float_or_false(val):
+    if isinstance(val, str) and val.lower() == "false":
+        return False
+    return float(val)
 
 
 def _supported_writers(is_polar2grid: bool = False) -> list[str]:

--- a/polar2grid/readers/modis_l1b.py
+++ b/polar2grid/readers/modis_l1b.py
@@ -144,7 +144,7 @@ from polar2grid.core.script_utils import ExtendConstAction
 
 from ._base import ReaderProxyBase
 
-PREFERRED_CHUNK_SIZE: int = 1400  # at least one 1km swath width
+PREFERRED_CHUNK_SIZE: int = 1354 * 2  # roughly the number columns in a 500m dataset
 
 FILTERS = {
     "day_only": {

--- a/polar2grid/readers/modis_l2.py
+++ b/polar2grid/readers/modis_l2.py
@@ -72,7 +72,7 @@ from satpy import DataQuery
 
 from ._base import ReaderProxyBase
 
-PREFERRED_CHUNK_SIZE: int = 1400  # at least one 1km swath width
+PREFERRED_CHUNK_SIZE: int = 1354 * 2  # roughly the number columns in a 500m dataset
 
 PRODUCTS = [
     "cloud_mask",


### PR DESCRIPTION
This allows for the filtering to be completely skipped, potentially saving processing time.

This also includes an increase in the default MODIS chunk size for better performance.