### PR TITLE
Force MiRS reader to use limb-correction LUTs from P2G v2.3

### DIFF
--- a/etc/readers/mirs.yaml
+++ b/etc/readers/mirs.yaml
@@ -1,0 +1,14 @@
+reader:
+  data_files:
+    - url: "https://github.com/ssec/polar2grid/raw/p2g-v2.3.0b0/polar2grid/mirs/limball_atmsland.txt"
+      filename: "limbcoef_atmsland_snpp.txt"
+      known_hash: "396b5473dfb2ec8ef72687658bd383f4a06452892f9850e2ee0b557f1855a076"
+    - url: "https://github.com/ssec/polar2grid/raw/p2g-v2.3.0b0/polar2grid/mirs/limball_atmsland.txt"
+      filename: "limbcoef_atmsland_noaa20.txt"
+      known_hash: "396b5473dfb2ec8ef72687658bd383f4a06452892f9850e2ee0b557f1855a076"
+    - url: "https://github.com/ssec/polar2grid/raw/p2g-v2.3.0b0/polar2grid/mirs/limball_atmssea.txt"
+      filename: "limbcoef_atmssea_snpp.txt"
+      known_hash: "6f72b793edded6284f3abc75e7da3530a405eccffb4485b2071c159c62fbcae6"
+    - url: "https://github.com/ssec/polar2grid/raw/p2g-v2.3.0b0/polar2grid/mirs/limball_atmsland.txt"
+      filename: "limbcoef_atmssea_noaa20.txt"
+      known_hash: "6f72b793edded6284f3abc75e7da3530a405eccffb4485b2071c159c62fbcae6"


### PR DESCRIPTION
It was discovered that the new LUTs used in Satpy's MiRS reader product bad results when applied to SNPP, but only over land (NOAA-20 is fine):

![MIRS88GHz_v-20221220_182145](https://user-images.githubusercontent.com/1828519/210423964-120b1088-0d14-48ea-88fe-493d1f869abe.png)

The same image processed with v2.3 looks like:

![MIRS88GHz_v-20221220_182045](https://user-images.githubusercontent.com/1828519/210423999-9fbb00da-d44e-4c5a-bf24-a9f3ac6941ae.png)

The LUTs being used were published on [Zenodo](https://zenodo.org/record/4472664/) by @joleenf received from the original limb correction author. This pull request customizes the MiRS reader to use the LUTs from the P2G v2.3 release stored in github.

@kathys We should add it to the TODO list to contact the original authors and see what they have to say about this. Maybe they have new LUTs.