### PR TITLE
Fix software bundle creation not including P2G custom configs during aux download

### DIFF
--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -101,7 +101,10 @@ PSP_CONFIG_FILE=etc/polar2grid/pyspectral.yaml PSP_DATA_ROOT=pyspectral_data PSP
 echo "Downloading Satpy auxiliary data..."
 AUX_CACHE_DIR="${CACHE_DIR}/satpy_aux_data_${USER}"
 SATPY_DATA_DIR="${SB_NAME}/share/polar2grid/data"
-${PYTHON_RUNTIME_BASE}/bin/satpy_retrieve_all_aux_data --data-dir ${AUX_CACHE_DIR} || oops "Could not download Satpy auxiliary data"
+P2G_ETC_DIR="${SB_NAME}/libexec/python_runtime/etc/polar2grid"
+SATPY_CONFIG_PATH="${P2G_ETC_DIR}" \
+    ${PYTHON_RUNTIME_BASE}/bin/satpy_retrieve_all_aux_data \
+    --data-dir ${AUX_CACHE_DIR} || oops "Could not download Satpy auxiliary data"
 
 # Add the download_from_internet: False to the config
 echo "download_from_internet: False" >> ${SB_NAME}/etc/polar2grid/pyspectral.yaml

--- a/polar2grid/compare.py
+++ b/polar2grid/compare.py
@@ -425,7 +425,7 @@ class CompareHelper:
         if file_type is None:
             LOG.error(f"Could not determine how to compare file type (extension not recognized): {file1}.")
             return FileComparisonResults(file1, file2, False, True)
-        LOG.info(f"Comparing '{file2}' to known valid file '{file1}'.")
+        LOG.info(f"Comparing {file2!r} to known valid file {file1!r}.")
         comparison_results = file_type(
             file1,
             file2,

--- a/polar2grid/filters/resample_coverage.py
+++ b/polar2grid/filters/resample_coverage.py
@@ -100,7 +100,7 @@ class ResampleCoverageFilter(BaseFilter):
             return False
         logger.warning(
             f"Resampling found {coverage_fraction * 100:0.02f}% of the output grid "
-            f"'{self._target_area.area_id}' covered. Will skip producing this product: {data_arr.attrs['name']}",
+            f"{self._target_area.area_id!r} covered. Will skip producing this product: {data_arr.attrs['name']}",
         )
         return True
 

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -440,7 +440,7 @@ def _check_valid_config_paths(extra_config_paths: Iterable):
 def _create_tmp_enhancement_config_dir(enh_yaml_file: str) -> str:
     config_dir = tempfile.mkdtemp(prefix="p2g_tmp_config")
     enh_dir = os.path.join(config_dir, "enhancements")
-    LOG.debug(f"Creating temporary config directory for enhancement file '{enh_yaml_file}': {enh_dir}")
+    LOG.debug(f"Creating temporary config directory for enhancement file {enh_yaml_file!r}: {enh_dir}")
     os.makedirs(enh_dir)
 
     new_enh_file = os.path.join(enh_dir, "generic.yaml")

--- a/polar2grid/grids/manager.py
+++ b/polar2grid/grids/manager.py
@@ -159,7 +159,7 @@ def _parse_optional_config_param(str_part, convert_func, unspecified_info=None):
         return convert_func(str_part)
     if unspecified_info is not None:
         grid_name, param_name = unspecified_info
-        LOG.warning(f"Grid '{grid_name}' may not process properly due to unspecified {param_name}")
+        LOG.warning(f"Grid {grid_name!r} may not process properly due to unspecified {param_name}")
     return None
 
 


### PR DESCRIPTION
Kathy noticed that the custom MiRS LUTS we're using weren't being included in the swbundle tarball. This was because the Satpy utility script wasn't being told about the custom P2G YAML configs where the LUTs to use were being modified.