### PR TITLE
Fix HDF5 writer not having a default output filename

### DIFF
--- a/etc/writers/hdf5.yaml
+++ b/etc/writers/hdf5.yaml
@@ -2,5 +2,4 @@ writer:
   name: hdf5
   description: Generic hdf5 Writer
   writer: !!python/name:polar2grid.writers.hdf5.HDF5Writer
-  #filename:
-  #    "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.h5"
+  filename: "{platform_name}_{sensor}_{start_time:%Y%m%d_%H%M%S}.h5"


### PR DESCRIPTION
This isn't normally a problem since P2G always provides one from the command line arguments, but some Satpy utility scripts need to be able to create the writer without any additional arguments (like downloading auxiliary data).