### PR TITLE
Fix integration tests not being specific enough when listing products

### DIFF
--- a/integration_tests/features/steps/compare_images.py
+++ b/integration_tests/features/steps/compare_images.py
@@ -130,7 +130,7 @@ def step_impl_compare_output(context, output):
     output = context.output
     try:
         for product_name in names_to_check:
-            num_products_in_output = output.count(product_name + "\n")
+            num_products_in_output = output.count(f"\n{product_name}\n")
             assert num_products_in_output != 0, f"Missing {product_name} in command output"
             assert num_products_in_output == 1, f"Too many of {product_name} in command output"
     finally:


### PR DESCRIPTION
Was checking for the existence of `true_color\n` when I should have been checking for `\ntrue_color\n`. This only affects the integration tests, not actual running code.