### PR TITLE
Fix compare script HTML not having a pixel percentage on failure

### DIFF
--- a/integration_tests/features/environment.py
+++ b/integration_tests/features/environment.py
@@ -34,6 +34,7 @@ def before_all(context):
     context.datapath = context.config.userdata["datapath"]
     if not context.datapath.startswith(os.sep):
         context.datapath = os.path.join(os.getcwd(), context.datapath)
+    os.environ["DATA_PATH"] = context.datapath  # for test command replacement
     p2g_home = os.environ.get("POLAR2GRID_HOME")
     # if POLAR2GRID_HOME isn't defined, assume things are installed in the python prefix
     context.p2g_path = os.path.join(p2g_home, "bin") if p2g_home is not None else os.path.join(sys.prefix, "bin")

--- a/integration_tests/features/polar2grid.feature
+++ b/integration_tests/features/polar2grid.feature
@@ -33,7 +33,7 @@ Feature: Test polar2grid output images
 
     Examples: VIIRS_L1B
       | command                                                                                                                                                                                           | source                      | output                        |
-      | polar2grid.sh -r viirs_l1b -w geotiff -vv --grid-configs /data/dist/p2g_test_data/viirs_l1b_night/input/test1/my_grid.conf -g polar_europe -p adaptive_dnb dynamic_dnb histogram_dnb hncc_dnb -f  | viirs_l1b_night/input/test1 | viirs_l1b_night/output/test1  |
+      | polar2grid.sh -r viirs_l1b -w geotiff -vv --grid-configs ${DATA_PATH}/viirs_l1b_night/input/test1/my_grid.conf -g polar_europe -p adaptive_dnb dynamic_dnb histogram_dnb hncc_dnb -f  | viirs_l1b_night/input/test1 | viirs_l1b_night/output/test1  |
 
     Examples: VIIRS_SDR
       | command                                                                                      | source                      | output                       |

--- a/polar2grid/compare.py
+++ b/polar2grid/compare.py
@@ -48,6 +48,12 @@ class ArrayComparisonResult:
     def failed(self):
         return self.different_shape or not self.almost_equal
 
+    @property
+    def diff_percentage(self):
+        if not self.total_pixels or self.different_shape:
+            return 100.0
+        return self.num_diff_pixels / self.total_pixels * 100
+
 
 @dataclass
 class FlatArrayComparisonResult(ArrayComparisonResult):
@@ -561,13 +567,11 @@ def _generate_subresult_table_row(
 ) -> str:
     status = "FAILED" if sub_result.failed else "PASSED"
     notes = ""
-    diff_percent = 100
+    diff_percent = sub_result.diff_percentage
     if sub_result.different_shape:
         notes = "Different array shapes"
     elif sub_result.failed:
         notes = "Too many differing pixels"
-    else:
-        diff_percent = sub_result.num_diff_pixels / sub_result.total_pixels * 100
 
     variable = getattr(sub_result, "variable", None)
     exp_tn_html = _generate_thumbnail_html(


### PR DESCRIPTION
I noticed the different number of pixels percentage wasn't accurate (said 100%) when there were any differing pixels. This PR makes it more accurate along with a couple other changes.