### PR TITLE
Add `--clip-negative-radiances` flag to ABI L1b reader

### DIFF
--- a/polar2grid/core/script_utils.py
+++ b/polar2grid/core/script_utils.py
@@ -46,11 +46,6 @@ import os
 import sys
 from collections import defaultdict
 
-try:
-    from argparse import BooleanOptionalAction
-except ImportError:
-    BooleanOptionalAction = None
-
 LOG = logging.getLogger(__name__)
 
 
@@ -311,52 +306,3 @@ def create_basic_parser(*args, **kwargs):
         help="exit on first error including non-fatal errors",
     )
     return parser
-
-
-# Backport of BooleanOptionalAction (added in Python 3.9)
-class _BooleanOptionalAction(argparse.Action):
-    def __init__(
-        self,
-        option_strings,
-        dest,
-        const=None,
-        default=None,
-        type=None,
-        choices=None,
-        required=False,
-        help=None,
-        metavar=None,
-    ):
-        _option_strings = []
-        for option_string in option_strings:
-            _option_strings.append(option_string)
-
-            if option_string.startswith("--"):
-                option_string = "--no-" + option_string[2:]
-                _option_strings.append(option_string)
-
-        if help is not None and default is not None:
-            help += f" (default: {default})"
-
-        super().__init__(
-            option_strings=_option_strings,
-            dest=dest,
-            nargs=0,
-            default=default,
-            type=type,
-            choices=choices,
-            required=required,
-            help=help,
-            metavar=metavar,
-        )
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        if option_string in self.option_strings:
-            setattr(namespace, self.dest, not option_string.startswith("--no-"))
-
-    def format_usage(self):
-        return " | ".join(self.option_strings)
-
-
-if BooleanOptionalAction is None:
-    BooleanOptionalAction = _BooleanOptionalAction

--- a/polar2grid/readers/abi_l1b.py
+++ b/polar2grid/readers/abi_l1b.py
@@ -98,7 +98,7 @@ more information on the creation of RGBs, please see the
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
+from argparse import ArgumentParser, BooleanOptionalAction, _ArgumentGroup
 from typing import Optional
 
 from ._base import ReaderProxyBase
@@ -142,5 +142,10 @@ def add_reader_argument_groups(
     """
     if group is None:
         group = parser.add_argument_group(title="ABI L1b Reader")
-    group.add_argument("--clip-negative-radiances")
+    group.add_argument(
+        "--clip-negative-radiances",
+        action=BooleanOptionalAction,
+        default=True,
+        help="Clip negative radiances for IR bands. Default is to perform the clipping.",
+    )
     return group, None

--- a/polar2grid/readers/abi_l1b.py
+++ b/polar2grid/readers/abi_l1b.py
@@ -142,4 +142,5 @@ def add_reader_argument_groups(
     """
     if group is None:
         group = parser.add_argument_group(title="ABI L1b Reader")
+    group.add_argument("--clip-negative-radiances")
     return group, None

--- a/polar2grid/readers/ahi_hsd.py
+++ b/polar2grid/readers/ahi_hsd.py
@@ -96,10 +96,9 @@ more information on the creation of RGBs, please see the
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
+from argparse import ArgumentParser, BooleanOptionalAction, _ArgumentGroup
 from typing import Optional
 
-from ..core.script_utils import BooleanOptionalAction
 from ._base import ReaderProxyBase
 
 PREFERRED_CHUNK_SIZE: int = 2200  # one segment

--- a/polar2grid/writers/awips_tiled.py
+++ b/polar2grid/writers/awips_tiled.py
@@ -82,8 +82,8 @@ see the Satpy documentation :mod:`here <satpy.writers.awips_tiled>`.
 
 """
 import logging
+from argparse import BooleanOptionalAction
 
-from polar2grid.core.script_utils import BooleanOptionalAction
 from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
 
 LOG = logging.getLogger(__name__)

--- a/polar2grid/writers/geotiff.py
+++ b/polar2grid/writers/geotiff.py
@@ -41,9 +41,10 @@ as transparent in most image viewers.
 import argparse
 import logging
 import os
+from argparse import BooleanOptionalAction
 
 from polar2grid.core.dtype import NUMPY_DTYPE_STRS, int_or_float, str_to_dtype
-from polar2grid.core.script_utils import BooleanOptionalAction, NumpyDtypeList
+from polar2grid.core.script_utils import NumpyDtypeList
 from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
This flag (on by default) removes negative radiances and therefore NaN brightness temperatures. These show up in RGBs that use them, but does not solve what I had hoped it would solve as described in #499. The night_microphysics's use of C07 and the green pixels that show up are inevitable due to how C07 works. Not much we can do about that. This PR does still fix some black pixels in the RGB though.