### PR TITLE
Change default ABI C07 enhancement to linear 400.15K to 164.15K

### DIFF
--- a/etc/enhancements/abi.yaml
+++ b/etc/enhancements/abi.yaml
@@ -12,6 +12,12 @@ enhancements:
          xp: [0., 25., 55., 100., 255.]
          fp: [0., 90., 140., 175., 255.]
          reference_scale_factor: 255
+  channel_7_default:
+    name: C07
+    operations:
+      - name: linear
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 400.15, max_stretch: 164.15}
   channel_8_default:
     name: C08
     operations:

--- a/etc/enhancements/agri.yaml
+++ b/etc/enhancements/agri.yaml
@@ -12,6 +12,12 @@ enhancements:
          xp: [0., 25., 55., 100., 255.]
          fp: [0., 90., 140., 175., 255.]
          reference_scale_factor: 255
+  channel_7_default:
+    name: C07
+    operations:
+      - name: linear
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 400.15, max_stretch: 164.15}
   channel_8_default:
     name: C08
     operations:

--- a/etc/enhancements/ahi.yaml
+++ b/etc/enhancements/ahi.yaml
@@ -12,6 +12,12 @@ enhancements:
           xp: [0., 25., 55., 100., 255.]
           fp: [0., 90., 140., 175., 255.]
           reference_scale_factor: 255
+  channel_7_default:
+    name: B07
+    operations:
+      - name: linear
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 400.15, max_stretch: 164.15}
   channel_8_default:
     name: B08
     operations:

--- a/etc/enhancements/ami.yaml
+++ b/etc/enhancements/ami.yaml
@@ -12,6 +12,12 @@ enhancements:
          xp: [0., 25., 55., 100., 255.]
          fp: [0., 90., 140., 175., 255.]
          reference_scale_factor: 255
+  channel_7_default:
+    name: SW038
+    operations:
+      - name: linear
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 400.15, max_stretch: 164.15}
   channel_8_default:
     name: WV063
     operations:


### PR DESCRIPTION
Replaces #641. Closes #278. After talking with @jpnIII and others in the NOAA Imagery team, we think it would be best to match AWIPS rather than do the 3 range piecewise function suggested in #278 and implemented in #641. AWIPS does a simple linear scaling from 127C to -109C. I added 273.15 to these values and put them in the YAML for ABI.

@jpnIII and @scottlindstrom Does it make sense to apply this change to AMI, AHI, and AGRI? I have a similar linear range for C08/C09/C10 (280K to 180K) for all 4 of these instruments.