### PR TITLE
Separate integration test working directories by feature name

### DIFF
--- a/integration_tests/features/environment.py
+++ b/integration_tests/features/environment.py
@@ -43,13 +43,17 @@ def before_all(context):
         import polar2grid
 
         os.environ["POLAR2GRID_HOME"] = os.path.join(os.path.dirname(polar2grid.__file__), "..", "swbundle")
+
+
+def before_feature(context, feature):
     tmpdir = tempfile.gettempdir()
-    context.base_temp_dir = os.path.join(tmpdir, "p2g_integration_tests")
+    feature_name = os.path.basename(feature.filename).replace("<", "").replace(">", "").replace(".feature", "")
+    context.base_temp_dir = os.path.join(tmpdir, "p2g_integration_tests", feature_name)
 
     # remove any previous test results
     if os.path.isdir(context.base_temp_dir):
         shutil.rmtree(context.base_temp_dir, ignore_errors=True)
-    os.mkdir(context.base_temp_dir)
+    os.makedirs(context.base_temp_dir, exist_ok=True)
 
 
 def after_all(context):

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -452,7 +452,6 @@ def _set_preferred_chunk_size(preferred_chunk_size: int) -> None:
     pcs_in_mb = (preferred_chunk_size * preferred_chunk_size) * 8 // (1024 * 1024)
     if "PYTROLL_CHUNK_SIZE" not in os.environ:
         LOG.debug(f"Setting preferred chunk size to {preferred_chunk_size} pixels or {pcs_in_mb:d}MiB")
-        satpy.CHUNK_SIZE = preferred_chunk_size
         os.environ["PYTROLL_CHUNK_SIZE"] = f"{preferred_chunk_size:d}"
         dask.config.set({"array.chunk-size": f"{pcs_in_mb:d}MiB"})
     else:


### PR DESCRIPTION
Geo2Grid working directories were being deleted to make room for Polar2Grid tests, but I need to see those results when there are failures. This creates subdirectories for each set of tests.