### PR TITLE
Cleanup test warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
   cancel-in-progress: true
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   CACHE_NUMBER: 1

--- a/build_environment.yml
+++ b/build_environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - requests
   - setuptools
   - six
-  - trollimage>=1.21.0
+  - trollimage>=1.22.2
   - trollsift>=0.5.0
   - scipy
   - zarr

--- a/polar2grid/add_coastlines.py
+++ b/polar2grid/add_coastlines.py
@@ -34,12 +34,12 @@ import argparse
 import logging
 import os
 import sys
+from pathlib import Path
 
 import numpy as np
 import rasterio
 from aggdraw import Font
 from PIL import Image, ImageFont
-from pkg_resources import resource_filename as get_resource_filename
 from pycoast import ContourWriterAGG
 from pydecorate import DecoratorAGG
 from pyresample.utils import get_area_def_from_raster
@@ -485,10 +485,10 @@ def find_font(font_name, size):
         font = ImageFont.truetype(font_name, size)
         return font.path
     except IOError as err:
-        font_path = get_resource_filename("polar2grid.fonts", font_name)
-        if not os.path.exists(font_path):
-            raise ValueError("Font path does not exist: {}".format(font_path)) from err
-        return font_path
+        font_path = Path(__file__).parent / "fonts" / font_name
+        if not font_path.is_file():
+            raise ValueError(f"Font path does not exist: {font_path}") from err
+        return str(font_path)
 
 
 def _process_one_image(

--- a/polar2grid/filters/_utils.py
+++ b/polar2grid/filters/_utils.py
@@ -36,7 +36,7 @@ except ImportError:
 from typing import Union
 
 from pyresample.boundary import AreaBoundary, AreaDefBoundary, Boundary
-from pyresample.geometry import AreaDefinition, SwathDefinition, get_geostationary_bounding_box
+from pyresample.geometry import AreaDefinition, SwathDefinition, get_geostationary_bounding_box_in_lonlats
 from pyresample.spherical import SphPolygon
 
 logger = logging.getLogger(__name__)
@@ -47,11 +47,12 @@ PRGeometry = Union[SwathDefinition, AreaDefinition]
 def boundary_for_area(area_def: PRGeometry) -> Boundary:
     """Create Boundary object representing the provided area."""
     if getattr(area_def, "is_geostationary", False):
-        adp = Boundary(*get_geostationary_bounding_box(area_def, nb_points=100))
+        adp = Boundary(*get_geostationary_bounding_box_in_lonlats(area_def, nb_points=100))
     else:
         freq_fraction = 0.30 if isinstance(area_def, AreaDefinition) else 0.05
         try:
-            adp = AreaDefBoundary(area_def, frequency=int(area_def.shape[0] * freq_fraction))
+            adp = area_def.boundary()
+            adp.decimate(int(freq_fraction * area_def.shape[0]))
         except ValueError:
             if not isinstance(area_def, SwathDefinition):
                 logger.error("Unable to generate bounding geolocation polygon")

--- a/polar2grid/tests/test_add_coastlines.py
+++ b/polar2grid/tests/test_add_coastlines.py
@@ -171,8 +171,10 @@ def test_add_coastlines_basic(
     passed_cmap = add_scale_mock.call_args.kwargs["colormap"]
     _check_used_colormap(passed_cmap, has_colors, include_cmap_tag, include_scale_offset)
 
-    img = Image.open(output_fp)
-    arr = np.asarray(img)
+    with Image.open(output_fp) as img:
+        img.load()
+        arr = np.asarray(img)
+        out_tags = dict(img.tag_v2) if output_fp.endswith(".tif") else {}
     # bottom of the image is a colorbar
     image_arr = arr[:940]
     _check_exp_image_colors(image_arr, colormap, 0, has_colors)
@@ -181,9 +183,9 @@ def test_add_coastlines_basic(
     assert (arr[940:] != 0).any()
 
     if output_fp.endswith(".tif"):
-        out_tags = dict(img.tag_v2)
-        in_img = Image.open(fp)
-        in_tags = dict(in_img.tag_v2)
+        with Image.open(fp) as in_img:
+            in_img.load()
+            in_tags = dict(in_img.tag_v2)
         assert len(out_tags) >= 14
         for key, val in out_tags.items():
             if key < 30000:

--- a/polar2grid/tests/test_compare.py
+++ b/polar2grid/tests/test_compare.py
@@ -21,13 +21,13 @@
 # input into another program.
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
 """Tests for the compare.py script."""
-import contextlib
 import os
-import warnings
 from glob import glob
 
 import numpy as np
 import pytest
+
+from polar2grid.utils.warnings import ignore_no_georef
 
 SHAPE1 = (200, 100)
 SHAPE2 = (200, 101)
@@ -42,20 +42,6 @@ IMAGE6_RGBA_UINT8_ZEROS = np.zeros((4,) + SHAPE1, dtype=np.uint8)
 IMAGE7_RGB_UINT8_ONES = np.ones((3,) + SHAPE1, dtype=np.uint8)
 IMAGE_LIST1 = [IMAGE1_L_UINT8_ZEROS, IMAGE1_L_UINT8_ZEROS]
 IMAGE_LIST2 = [IMAGE1_L_UINT8_ZEROS, IMAGE2_L_UINT8_ZEROS, IMAGE4_RGB_UINT8_ZEROS]
-
-
-@contextlib.contextmanager
-def ignore_no_georef():
-    """Wrap operations that we know will produce a rasterio geolocation warning."""
-    from rasterio.errors import NotGeoreferencedWarning
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            "Dataset has no geotransform",
-            NotGeoreferencedWarning,
-        )
-        yield
 
 
 def _create_geotiffs(base_dir, img_data):

--- a/polar2grid/tests/test_configs.py
+++ b/polar2grid/tests/test_configs.py
@@ -35,9 +35,10 @@ def pytest_generate_tests(metafunc):
 
     """
     if "yaml_config_file" in metafunc.fixturenames:
-        root_dir = os.path.join(os.path.dirname(__file__), "..", "..")
+        root_dir = os.path.join(os.path.dirname(__file__), "..")
         glob_pat = os.path.join(root_dir, "etc", "**", "*.yaml")
         p2g_yaml_files = sorted(glob(glob_pat, recursive=True))
+        assert len(p2g_yaml_files) != 0
         metafunc.parametrize("yaml_config_file", p2g_yaml_files)
 
 

--- a/polar2grid/tests/test_glue.py
+++ b/polar2grid/tests/test_glue.py
@@ -35,6 +35,7 @@ from pytest_lazyfixture import lazy_fixture
 from satpy.tests.utils import CustomScheduler
 
 from polar2grid.utils.config import get_polar2grid_etc
+from polar2grid.utils.warnings import ignore_no_georef
 
 
 @contextlib.contextmanager
@@ -294,7 +295,8 @@ class TestGlueFakeScene:
                 args.extend(product_names)
             if extra_flags:
                 args.extend(extra_flags)
-            ret = main(args)
+            with ignore_no_georef():
+                ret = main(args)
         output_files = glob(str(chtmpdir / "*.tif"))
         assert len(output_files) == num_outputs
         assert ret == 0

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -24,9 +24,7 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
-import warnings
 from typing import Generator, Iterable, Optional, Union
 
 from satpy import DataID, DataQuery, Scene
@@ -259,22 +257,3 @@ def get_sensor_alias(satpy_sensor):
     if len(new_sensor) == 1:
         return new_sensor.pop()
     return new_sensor
-
-
-@contextlib.contextmanager
-def ignore_pyproj_proj_warnings():
-    """Wrap operations that we know will produce a PROJ.4 precision warning.
-
-    Only to be used internally to Pyresample when we have no other choice but
-    to use PROJ.4 strings/dicts. For example, serialization to YAML or other
-    human-readable formats or testing the methods that produce the PROJ.4
-    versions of the CRS.
-
-    """
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            "You will likely lose important projection information",
-            UserWarning,
-        )
-        yield

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -24,7 +24,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import warnings
 from typing import Generator, Iterable, Optional, Union
 
 from satpy import DataID, DataQuery, Scene
@@ -257,3 +259,22 @@ def get_sensor_alias(satpy_sensor):
     if len(new_sensor) == 1:
         return new_sensor.pop()
     return new_sensor
+
+
+@contextlib.contextmanager
+def ignore_pyproj_proj_warnings():
+    """Wrap operations that we know will produce a PROJ.4 precision warning.
+
+    Only to be used internally to Pyresample when we have no other choice but
+    to use PROJ.4 strings/dicts. For example, serialization to YAML or other
+    human-readable formats or testing the methods that produce the PROJ.4
+    versions of the CRS.
+
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "You will likely lose important projection information",
+            UserWarning,
+        )
+        yield

--- a/polar2grid/utils/warnings.py
+++ b/polar2grid/utils/warnings.py
@@ -1,0 +1,38 @@
+"""Warnings or utilities for dealing with warnings."""
+from __future__ import annotations
+
+import contextlib
+import warnings
+
+
+@contextlib.contextmanager
+def ignore_no_georef():
+    """Wrap operations that we know will produce a rasterio geolocation warning."""
+    from rasterio.errors import NotGeoreferencedWarning
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "Dataset has no geotransform",
+            NotGeoreferencedWarning,
+        )
+        yield
+
+
+@contextlib.contextmanager
+def ignore_pyproj_proj_warnings():
+    """Wrap operations that we know will produce a PROJ.4 precision warning.
+
+    Only to be used internally to Pyresample when we have no other choice but
+    to use PROJ.4 strings/dicts. For example, serialization to YAML or other
+    human-readable formats or testing the methods that produce the PROJ.4
+    versions of the CRS.
+
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "You will likely lose important projection information",
+            UserWarning,
+        )
+        yield

--- a/polar2grid/writers/hdf5.py
+++ b/polar2grid/writers/hdf5.py
@@ -52,7 +52,8 @@ import xarray as xr
 from pyresample.geometry import SwathDefinition
 from satpy.writers import Writer, compute_writer_results, split_results
 
-from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy, ignore_pyproj_proj_warnings
+from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
+from polar2grid.utils.warnings import ignore_pyproj_proj_warnings
 from polar2grid.writers.geotiff import NUMPY_DTYPE_STRS, NumpyDtypeList, str_to_dtype
 
 LOG = logging.getLogger(__name__)

--- a/polar2grid/writers/hdf5.py
+++ b/polar2grid/writers/hdf5.py
@@ -52,7 +52,7 @@ import xarray as xr
 from pyresample.geometry import SwathDefinition
 from satpy.writers import Writer, compute_writer_results, split_results
 
-from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy
+from polar2grid.utils.legacy_compat import convert_p2g_pattern_to_satpy, ignore_pyproj_proj_warnings
 from polar2grid.writers.geotiff import NUMPY_DTYPE_STRS, NumpyDtypeList, str_to_dtype
 
 LOG = logging.getLogger(__name__)
@@ -163,7 +163,8 @@ class HDF5Writer(Writer):
             group.attrs["height"], group.attrs["width"] = area_def.shape
             group.attrs["description"] = "No projection: native format"
         else:
-            group.attrs["proj4_definition"] = area_def.proj4_string
+            with ignore_pyproj_proj_warnings():
+                group.attrs["proj4_definition"] = area_def.crs.to_string()
             for a in ["height", "width"]:
                 ds_attr = getattr(area_def, a, None)
                 if ds_attr is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ include-package-data = true
 [tool.setuptools.packages]
 find = {}
 
+[tool.pytest.ini_options]
+minversion = 7.0
+
 [tool.coverage.run]
 relative_files = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,16 @@ include-package-data = true
 find = {}
 
 [tool.pytest.ini_options]
-minversion = 7.0
+minversion = 6.0
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+xfail_strict = true
+log_cli_level = "info"
+testpaths = ["polar2grid/tests"]
+filterwarnings = [
+    "error",
+    "ignore:numpy.ndarray size changed, may indicate binary incompatibility:RuntimeWarning",
+    "ignore:The `frequency` argument is pending deprecation:PendingDeprecationWarning"
+]
 
 [tool.coverage.run]
 relative_files = true


### PR DESCRIPTION
In general it is bad to have warnings go unnoticed/unfailing when running tests. It is a sign that:

1. Users are seeing warnings
2. Something is being deprecated and should be dealt with

Some of the warnings currently appearing will be fixed by https://github.com/pytroll/pyspectral/pull/207