### PR TITLE
Add custom MiRS reader configuration for duplicated NOAA-20 coeffs as NOAA-21

### DIFF
--- a/polar2grid/etc/readers/mirs.yaml
+++ b/polar2grid/etc/readers/mirs.yaml
@@ -1,0 +1,17 @@
+reader:
+  data_files:
+     - url: "https://zenodo.org/record/10357932/files/limbcoef_atmsland_noaa20.txt"
+       known_hash: "08deca15afe8638effac9e6ccb442c2c386f5444926129d30a250d5840264c1d"
+     - url: "https://zenodo.org/record/10357932/files/limbcoef_atmsland_snpp.txt"
+       known_hash: "4b01543699792306711ef1699244e96186487e8a869e4ae42bf1f0e4d00fd063"
+     - url: "https://zenodo.org/record/10357932/files/limbcoef_atmssea_noaa20.txt"
+       known_hash: "07cd7874ff3f069cc3d473bdd0d1d19880ef01ac8d75cb0212a3687c059557f4"
+     - url: "https://zenodo.org/record/10357932/files/limbcoef_atmssea_snpp.txt"
+       known_hash: "d0f806051b80320e046bdae6a9b68616152bbf8c2dbf3667b9834459259c0d72"
+     # Temporary copy of noaa-20 files as noaa-21 files
+     - url: "https://zenodo.org/record/10357932/files/limbcoef_atmsland_noaa20.txt"
+       known_hash: "08deca15afe8638effac9e6ccb442c2c386f5444926129d30a250d5840264c1d"
+       filename: "limbcoef_atmsland_noaa21.txt"
+     - url: "https://zenodo.org/record/10357932/files/limbcoef_atmssea_noaa20.txt"
+       known_hash: "07cd7874ff3f069cc3d473bdd0d1d19880ef01ac8d75cb0212a3687c059557f4"
+       filename: "limbcoef_atmssea_noaa21.txt"

--- a/polar2grid/readers/mirs.py
+++ b/polar2grid/readers/mirs.py
@@ -174,7 +174,7 @@ As an example, the ATMS band options are:
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
+from argparse import ArgumentParser, _ArgumentGroup, BooleanOptionalAction
 from typing import Optional, Union
 
 from satpy import DataID, Scene
@@ -266,4 +266,10 @@ def add_reader_argument_groups(
         const=["all_bt_channels"],
         help="Add all bands to list of products",
     )
-    return None, None
+    group.add_argument(
+        "--limb-correction",
+        default=True,
+        action=BooleanOptionalAction,
+        help="Perform limb correction on ATMS instrument BT channels (enabled by default)",
+    )
+    return group, None


### PR DESCRIPTION
Closes #669 

Also adds --no-limb-correction command line flag and fixes issue where MiRS reader command line arguments were ignored.