### PR TITLE
Switch to unstable sphinx-argparse for better documentation section numbers

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -43,10 +43,11 @@ dependencies:
   - sphinx
   - pip
   - python-graphviz
-  - sphinx-argparse
+#  - sphinx-argparse
   - fsspec
   - s3fs
   - sphinxcontrib-apidoc
   - pip:
       - git+https://github.com/pytroll/satpy.git
       - git+https://github.com/pytroll/pyresample.git
+      - git+https://github.com/djhoese/sphinx-argparse.git@bugfix-section-nums

--- a/jenkins_environment.yml
+++ b/jenkins_environment.yml
@@ -11,5 +11,6 @@ dependencies:
   - matplotlib
   - pip:
     - graphviz
-    - sphinx-argparse
+#    - sphinx-argparse
+    - git+https://github.com/djhoese/sphinx-argparse.git@bugfix-section-nums
     - sphinxcontrib-apidoc


### PR DESCRIPTION
Sphinx-argparse is a third-party tool used to put our command line arguments from the python code into our documentation in a pretty way. It currently has a bug where section numbers are not kept unique between argparse blocks in a single page/document of the documentation. This PR updates Polar2Grid's build steps to use my not-yet-merged pull request code to sphinx-argparse where this is fixed (or at least worked around).

Closes #289