### PR TITLE
Fix shell scripts not being added to PATH in software bundle

### DIFF
--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -121,6 +121,10 @@ for bash_file in *.sh; do
     sed -i "s/# __SWBUNDLE_ENVIRONMENT_INJECTION__/source \$POLAR2GRID_HOME\/bin\/env.sh/g" "$bash_file"
 done
 
+# Softlink bin/ scripts in python runtime so env.sh adds them to PATH
+cd  ${PYTHON_RUNTIME_BASE}/bin
+find ../../../bin/ -name "*.sh" ! -name "*env*" -exec ln -s {} . \;
+
 echo "Copying Satpy auxiliary data to software bundle..."
 mkdir -p ${SATPY_DATA_DIR} || oops "Could not create polar2grid auxiliary data directory"
 # don't include large geotiff files that we don't use in P2G/G2G


### PR DESCRIPTION
Closes #678 

As discussed in the related issue, changes in #654 deprecated old and unsupported use of copying/distributing `.sh` scripts as part of the `polar2grid` python package installation. When I made that change I didn't realize that I was depending on it as part of the `bin/env.sh` script.

To any users reading this, we still recommend never sourcing the environment scripts (ex. `source $POLAR2GRID_HOME/bin/polar2grid_env.sh`, but some users still do. Instead we recommend calling the high-level scripts with an absolute path (ex. `POLAR2GRID_HOME/bin/polar2grid.sh`).

This PR fixes this problem by softlinking the high-level `.sh` scripts into the low-level python runtime `libexec/python_runtime/bin/` directory. This avoids other things in `bin/` being added to your PATH.

In the long run, although not implemented here, the environment scripts should maybe be moved somewhere else (maybe the root directory) and not included in `bin/` as they are not scripts to be executed. That's a little too much backwards incompatible for one release so I'm not going to do it here.