### PR TITLE
Workaround swaths crossing the anti-meridian causing negative coverage percentages

### DIFF
--- a/polar2grid/filters/_utils.py
+++ b/polar2grid/filters/_utils.py
@@ -53,6 +53,9 @@ def boundary_for_area(area_def: PRGeometry) -> Boundary:
         try:
             adp = area_def.boundary()
             adp.decimate(int(freq_fraction * area_def.shape[0]))
+            if adp.contour_poly.area() < 0:
+                # https://github.com/ssec/polar2grid/issues/696
+                raise ValueError("Failed to generate valid polygon for area. Polygon has a negative area.")
         except ValueError:
             if not isinstance(area_def, SwathDefinition):
                 logger.error("Unable to generate bounding geolocation polygon")


### PR DESCRIPTION
This is a (hopefully) temporary workaround to handle the cases when swaths produce boundary polygons with negative areas. Overall this is a bug in pyresample and there are pull requests attempting to address it but they are not ready.