### PR TITLE
Update readers to default to real reflectances

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+Version 3.2.0 (unreleased)
+
+* Change default visible band output to apply '/ cos(SZA)'. Use '--normalized-radiances' for old behavior.
+
 Version 3.1.0 (2024-08-13)
 --------------------------
 

--- a/polar2grid/readers/viirs_sdr.py
+++ b/polar2grid/readers/viirs_sdr.py
@@ -188,20 +188,23 @@ from ._base import ReaderProxyBase
 
 PREFERRED_CHUNK_SIZE: int = 6400
 
-I_PRODUCTS = [
+I_VIS_PRODUCTS = [
     "I01",
     "I02",
     "I03",
+]
+I_IR_PRODUCTS = [
     "I04",
     "I05",
 ]
+I_PRODUCTS = I_VIS_PRODUCTS + I_IR_PRODUCTS
 I_ANGLE_PRODUCTS = [
     "i_solar_zenith_angle",
     "i_solar_azimuth_angle",
     "i_sat_zenith_angle",
     "i_sat_azimuth_angle",
 ]
-M_PRODUCTS = [
+M_VIS_PRODUCTS = [
     "M01",
     "M02",
     "M03",
@@ -213,12 +216,15 @@ M_PRODUCTS = [
     "M09",
     "M10",
     "M11",
+]
+M_IR_PRODUCTS = [
     "M12",
     "M13",
     "M14",
     "M15",
     "M16",
 ]
+M_PRODUCTS = M_VIS_PRODUCTS + M_IR_PRODUCTS
 M_ANGLE_PRODUCTS = [
     "m_solar_zenith_angle",
     "m_solar_azimuth_angle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,20 +72,22 @@ filterwarnings = [
 relative_files = true
 
 [tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
 # See https://docs.astral.sh/ruff/rules/
 select = ["E", "W", "B", "D", "T10", "C90"]
 # Remove D416 when all docstrings have been converted to google-style
 ignore = ["D101", "D102", "D103", "D104", "D105", "D106", "D107", "E203", "D416"]
-line-length = 120
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "doc/source/conf.py" = ["E501"]
 "polar2grid/readers/*.py" = ["D205", "D400", "D415", "S101"]  # assert allowed in tests
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
Adds `--normalized-radiances` command line option to restore previous behavior. This PR updates various Polar2Grid readers to that visible channels have `/ cos(SZA)` applied to them by default. This means the results should be "real" reflectances rather than accidentally producing "normalized radiances".

Closes #707 