### PR TITLE
Add workaround for pyresample polygon intersection anti-meridian handling

### DIFF
--- a/polar2grid/filters/_utils.py
+++ b/polar2grid/filters/_utils.py
@@ -53,8 +53,9 @@ def boundary_for_area(area_def: PRGeometry) -> Boundary:
         try:
             adp = area_def.boundary()
             adp.decimate(int(freq_fraction * area_def.shape[0]))
-            if adp.contour_poly.area() < 0:
+            if adp.contour_poly.area() < 0 or ((adp.vertices[:, 0] > 170).any() and (adp.vertices[:, 0] < -170).any()):
                 # https://github.com/ssec/polar2grid/issues/696
+                # https://github.com/ssec/polar2grid/issues/722
                 raise ValueError("Failed to generate valid polygon for area. Polygon has a negative area.")
         except ValueError:
             if not isinstance(area_def, SwathDefinition):


### PR DESCRIPTION
Closes #722. This is a simple and wasteful workaround to check polygon coordinates for if they cross the anti-meridian and if they do compute a bounding box from a min/max of those coordinates instead.