### PR TITLE
Update package build system to hatchling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,39 +52,16 @@ nosetests.xml
 *.out
 *.app
 
-# various built ms2gt files
-ms2gt/src/fornav/fornav
-ms2gt/src/grid_convert/grid_convert
-ms2gt/src/gridsize/gridsize
-ms2gt/src/ll2cr/ll2cr
-ms2gt/src/ll2xy/ll2xy
-ms2gt/src/lle2cre/lle2cre
-ms2gt/src/mapx/trunk/cdb_edit
-ms2gt/src/mapx/trunk/cdb_list
-ms2gt/src/mapx/trunk/crtest
-ms2gt/src/mapx/trunk/gacct
-ms2gt/src/mapx/trunk/gridloc
-ms2gt/src/mapx/trunk/gtest
-ms2gt/src/mapx/trunk/irregrid
-ms2gt/src/mapx/trunk/macct
-ms2gt/src/mapx/trunk/mapenum
-ms2gt/src/mapx/trunk/mtest
-ms2gt/src/mapx/trunk/regrid
-ms2gt/src/mapx/trunk/resamp
-ms2gt/src/mapx/trunk/ungrid
-ms2gt/src/mapx/trunk/wdbtocdb
-ms2gt/src/mapx/trunk/xytest
-ms2gt/src/projection/projection
-ms2gt/src/utils/apply_mask
-ms2gt/src/utils/extract_region
-ms2gt/src/utils/insert_region
-ms2gt/src/utils/make_mask
-ms2gt/src/xy2ll/xy2ll
-
 # PyCharm configs
 .idea
+
+# Image Editing Tools
+*.xcf
 
 # Example images should not be added to the repository
 doc/source/_static/example_images
 doc/source/dev_guide/api/*.rst
 doc/source/grids_list.rst
+
+# Polar2Grid Bundles being compared against
+polar2grid-swbundle-*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-recursive-include doc/source *
-recursive-include polar2grid/tests/etc *
-include polar2grid/grids/grids.yaml
-recursive-include polar2grid/fonts *
-recursive-include polar2grid/etc *
-include LICENSE.txt
-include README.rst
-recursive-exclude doc/source/_static/example_images *.png *.jpg
-recursive-exclude doc/source/_static *.psd *.xcf

--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -121,10 +121,6 @@ for bash_file in *.sh; do
     sed -i "s/# __SWBUNDLE_ENVIRONMENT_INJECTION__/source \$POLAR2GRID_HOME\/bin\/env.sh/g" "$bash_file"
 done
 
-# Softlink bin/ scripts in python runtime so env.sh adds them to PATH
-cd  ${PYTHON_RUNTIME_BASE}/bin
-find ../../../bin/ -name "*.sh" ! -name "*env*" -exec ln -s {} . \;
-
 echo "Copying Satpy auxiliary data to software bundle..."
 mkdir -p ${SATPY_DATA_DIR} || oops "Could not create polar2grid auxiliary data directory"
 # don't include large geotiff files that we don't use in P2G/G2G

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,24 @@ only-include = [
     "polar2grid",
     "NEWS.rst",
     "NEWS_GEO2GRID.rst",
+    "swbundle",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["polar2grid"]
+
+[tool.hatch.build.targets.wheel.shared-scripts]
+"swbundle/add_coastlines.sh" = "add_coastlines.sh"
+"swbundle/add_colormap.sh" = "add_colormap.sh"
+"swbundle/convert_grids_conf_to_yaml.sh" = "convert_grids_conf_to_yaml.sh"
+"swbundle/download_pyspectral_data.sh" = "download_pyspectral_data.sh"
+"swbundle/geo2grid.sh" = "geo2grid.sh"
+"swbundle/gtiff2kmz.sh" = "gtiff2kmz.sh"
+"swbundle/gtiff2mp4.sh" = "gtiff2mp4.sh"
+"swbundle/overlay.sh" = "overlay.sh"
+"swbundle/p2g_compare.sh" = "p2g_compare.sh"
+"swbundle/p2g_grid_helper.sh" = "p2g_grid_helper.sh"
+"swbundle/polar2grid.sh" = "polar2grid.sh"
 
 [tool.pytest.ini_options]
 minversion = 6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=45"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "polar2grid"
@@ -50,11 +50,15 @@ Project-URL = "https://github.com/ssec/polar2grid/"
 polar2grid = "polar2grid.__main__:p2g_main"
 geo2grid = "polar2grid.__main__:g2g_main"
 
-[tool.setuptools]
-include-package-data = true
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "polar2grid",
+    "NEWS.rst",
+    "NEWS_GEO2GRID.rst",
+]
 
-[tool.setuptools.packages]
-find = {}
+[tool.hatch.build.targets.wheel]
+packages = ["polar2grid"]
 
 [tool.pytest.ini_options]
 minversion = 6.0


### PR DESCRIPTION
This is my initial attempt to switch the python package building system from setuptools (old, but classic library) to hatchling (new hotness). My hope is that besides using more modern tooling, I'm hoping I'll be able to restore the bundled bash scripts (see #728).