### PR TITLE
Adds support for the MiRS Snow Grain Size product

### DIFF
--- a/polar2grid/etc/enhancements/generic.yaml
+++ b/polar2grid/etc/enhancements/generic.yaml
@@ -111,6 +111,13 @@ enhancements:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.stretch
         kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 50.0}
+  snow_grain_size:
+    name: SnowGS
+    # Uses NOAA STAR Snow Grain Size range: https://www.star.nesdis.noaa.gov/mirs/highresolutionv.php
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0.3, max_stretch: 0.7}
   # mirs_tpw: See higher up in configuration
 
   # MIRS BTs - ATMS

--- a/polar2grid/etc/writers/awips_tiled.yaml
+++ b/polar2grid/etc/writers/awips_tiled.yaml
@@ -758,3 +758,11 @@ templates:
           physical_element:
             raw_value: MIRS Skin Temperature
           units: {}
+      mirs_snow_grain_size:
+        reader: mirs
+        name: SnowGS
+        var_name: data
+        attributes:
+          physical_element:
+            raw_value: MIRS Snow Grain Size
+          units: {}

--- a/polar2grid/readers/mirs.py
+++ b/polar2grid/readers/mirs.py
@@ -63,6 +63,8 @@ frontend name.The frontend offers the following products:
     +--------------------+----------------------------------------------------+
     | tskin              | Skin Temperature                                   |
     +--------------------+----------------------------------------------------+
+    | snow_grain_size    | Snow Grain Size                                    |
+    +--------------------+----------------------------------------------------+
     | btemp_X            | Brightness Temperature for channel X (see below)   |
     +--------------------+----------------------------------------------------+
 
@@ -192,6 +194,7 @@ SNOW_PRODUCTS = [
     "snow_cover",
     "swe",
     "sfr",
+    "snow_grain_size",
 ]
 SEAICE_PRODUCTS = [
     "sea_ice",
@@ -205,6 +208,7 @@ PRODUCT_ALIASES["clw"] = "CLW"
 PRODUCT_ALIASES["snow_cover"] = "Snow"
 PRODUCT_ALIASES["swe"] = "SWE"
 PRODUCT_ALIASES["sfr"] = "SFR"
+PRODUCT_ALIASES["snow_grain_size"] = "SnowGS"
 
 PRODUCT_ALIASES["sea_ice"] = "SIce"
 


### PR DESCRIPTION
This pull request adds support for the MiRS Snow Grain Size product.  Both GeoTIFF and AWIPS tile production was tested successfully with these changes, using input from CSPP MiRS v4.0.  Below is a sample of a produced GeoTIFF with added colormap, title, geographic features, and colorbar using the included modifications to Polar2Grid:
![snow_grain_size_20250119_182856_MADISON](https://github.com/user-attachments/assets/74f881fc-7a76-4204-bca6-e5eb1fb88184)
