### PR TITLE
Add new ABI RGBs to abi_l1b reader

### DIFF
--- a/polar2grid/etc/enhancements/generic.yaml
+++ b/polar2grid/etc/enhancements/generic.yaml
@@ -333,54 +333,64 @@ enhancements:
   # Polar2Grid - CLAVR-x products
   clavrx_cloud_type:
     name: cloud_type
+    reader: clavrx
     operations: {}
   clavrx_cld_temp_acha:
     name: cld_temp_acha
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: {stretch: 'crude', min_stretch: 160, max_stretch: 320.}
   clavrx_cld_height_acha:
     name: cld_height_acha
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 20000.}
   clavrx_cloud_phase:
     name: cloud_phase
+    reader: clavrx
     operations: {}
   clavrx_cld_opd_dcomp:
     name: cld_opd_dcomp
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: {stretch: 'crude', min_stretch: -0.2, max_stretch: 160.}
   clavrx_cld_opd_nlcomp:
     name: cld_opd_nlcomp
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: {stretch: 'crude', min_stretch: -0.2, max_stretch: 160.}
   clavrx_cld_reff_dcomp:
     name: cld_reff_dcomp
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 160.}
   clavrx_cld_reff_nlcomp:
     name: cld_reff_nlcomp
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 160.}
   clavrx_cld_emiss_acha:
     name: cld_emiss_acha
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: {stretch: 'crude', min_stretch: 0, max_stretch: 1.}
   clavrx_refl_lunar_dnb_nom:
     name: refl_lunar_dnb_nom
+    reader: clavrx
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch

--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -419,7 +419,11 @@ def _prepare_initial_logging(arg_parser, glue_name: str) -> bool:
         rename_log = True
         args.log_fn = glue_name + "_fail.log"
     levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
-    setup_logging(console_level=levels[min(3, args.verbosity)], log_filename=args.log_fn)
+    if os.getenv("P2G_ALLOW_TRACE"):
+        from satpy.utils import TRACE_LEVEL
+
+        levels.append(TRACE_LEVEL)
+    setup_logging(console_level=levels[min(len(levels) - 1, args.verbosity)], log_filename=args.log_fn)
     logging.getLogger("rasterio").setLevel(levels[min(1, args.verbosity)])
     logging.getLogger("fsspec").setLevel(levels[min(2, args.verbosity)])
     logging.getLogger("s3fs").setLevel(levels[min(2, args.verbosity)])

--- a/polar2grid/readers/abi_l1b.py
+++ b/polar2grid/readers/abi_l1b.py
@@ -93,25 +93,13 @@ more information on the creation of RGBs, please see the
 +---------------------------+-----------------------------------------------------+
 | night_microphysics        | Night Microphysics RGB                              |
 +---------------------------+-----------------------------------------------------+
-| cloud_phase_distinction   | Day Cloud Phase Distinction RGB                     |
+| day_cloud_type            | Day Cloud Type RGB                                  |
 +---------------------------+-----------------------------------------------------+
-| cira_fire_temperature     | Fire Temperature RGB                                |
+| day_severe_storms         | Day Severe Storms RGB (aka. Day Convection)         |
 +---------------------------+-----------------------------------------------------+
-| snow_fog                  | Day Snow Fog RGB                                    |
+| volcanic_emissions_so2    | Volcanic Emissions (SO2 and Ash) (aka. SO2)         |
 +---------------------------+-----------------------------------------------------+
-| convection                | Day Convection RGB                                  |
-+---------------------------+-----------------------------------------------------+
-| land_cloud                | Day Land Cloud RGB                                  |
-+---------------------------+-----------------------------------------------------+
-| so2                       | SO2 RGB                                             |
-+---------------------------+-----------------------------------------------------+
-| blowing_snow              | Blowing Snow RGB                                    |
-+---------------------------+-----------------------------------------------------+
-| water_vapors1             | Simple Water Vapor RGB                              |
-+---------------------------+-----------------------------------------------------+
-| water_vapors2             | Differential Water Vapor RGB                        |
-+---------------------------+-----------------------------------------------------+
-| cloud_type                | Day Cloud Type RGB                                  |
+| day_blowing_snow          | Day Blowing Snow RGB                                |
 +---------------------------+-----------------------------------------------------+
 
 """
@@ -128,24 +116,23 @@ PREFERRED_CHUNK_SIZE: int = 1356
 READER_PRODUCTS = ["C{:02d}".format(x) for x in range(1, 17)]
 COMPOSITE_PRODUCTS = [
     "true_color",
-    "natural_color",
+    "natural_color",  # <-- considered legacy RGB Workshop 2025
     "airmass",
-    "ash",
-    "dust",
-    "fog",
+    "ash",  # <-- deprecated name as of RGB Workshop 2025 (preferred: 24h_microphysics_ash)
+    "dust",  # <-- deprecated name as of RGB Workshop 2025 (preferred: 24h_microphysics_dust)
+    "fog",  # <-- deprecated name as of RGB Workshop 2025 (preferred: night_microphysics)?
     "night_microphysics",
     # 2025 new
-    "cloud_phase_distinction",  # day cloud phase distinction
-    # "cloud_phase_distinction_raw",  # day cloud phase distinction
-    "cira_fire_temperature",
-    "snow_fog",  # day snow fog
-    "convection",  # day convection
-    "land_cloud",  # day land cloud
-    "water_vapors2",  # differential water vapor
-    "so2",  # SO2
-    "blowing_snow",
-    "water_vapors1",  # simple water vapor
-    "cloud_type",
+    "day_cloud_type",
+    "day_severe_storms",
+    "volanic_emissions_so2",  # old name: so2
+    "day_blowing_snow",
+    # "day_cloud_type_distinction",  # aka: day cloud phase distinction
+    # "cira_fire_temperature",
+    # "snow_fog",  # day snow fog - considered legacy RGB Workshop 2025
+    # "land_cloud",  # day land cloud - considered legacy RGB Workshop 2025
+    # "water_vapors2",  # differential water vapor - considered legacy RGB Workshop 2025
+    # "simple_water_vapor",  # aka: water_vapors1 (deprecated in Satpy)
 ]
 
 

--- a/polar2grid/readers/abi_l1b.py
+++ b/polar2grid/readers/abi_l1b.py
@@ -93,6 +93,26 @@ more information on the creation of RGBs, please see the
 +---------------------------+-----------------------------------------------------+
 | night_microphysics        | Night Microphysics RGB                              |
 +---------------------------+-----------------------------------------------------+
+| cloud_phase_distinction   | Day Cloud Phase Distinction RGB                     |
++---------------------------+-----------------------------------------------------+
+| cira_fire_temperature     | Fire Temperature RGB                                |
++---------------------------+-----------------------------------------------------+
+| snow_fog                  | Day Snow Fog RGB                                    |
++---------------------------+-----------------------------------------------------+
+| convection                | Day Convection RGB                                  |
++---------------------------+-----------------------------------------------------+
+| land_cloud                | Day Land Cloud RGB                                  |
++---------------------------+-----------------------------------------------------+
+| so2                       | SO2 RGB                                             |
++---------------------------+-----------------------------------------------------+
+| blowing_snow              | Blowing Snow RGB                                    |
++---------------------------+-----------------------------------------------------+
+| water_vapors1             | Simple Water Vapor RGB                              |
++---------------------------+-----------------------------------------------------+
+| water_vapors2             | Differential Water Vapor RGB                        |
++---------------------------+-----------------------------------------------------+
+| cloud_type                | Day Cloud Type RGB                                  |
++---------------------------+-----------------------------------------------------+
 
 """
 
@@ -114,6 +134,18 @@ COMPOSITE_PRODUCTS = [
     "dust",
     "fog",
     "night_microphysics",
+    # 2025 new
+    "cloud_phase_distinction",  # day cloud phase distinction
+    # "cloud_phase_distinction_raw",  # day cloud phase distinction
+    "cira_fire_temperature",
+    "snow_fog",  # day snow fog
+    "convection",  # day convection
+    "land_cloud",  # day land cloud
+    "water_vapors2",  # differential water vapor
+    "so2",  # SO2
+    "blowing_snow",
+    "water_vapors1",  # simple water vapor
+    "cloud_type",
 ]
 
 

--- a/polar2grid/readers/abi_l1b.py
+++ b/polar2grid/readers/abi_l1b.py
@@ -125,7 +125,7 @@ COMPOSITE_PRODUCTS = [
     # 2025 new
     "day_cloud_type",
     "day_severe_storms",
-    "volanic_emissions",  # old name: so2
+    "volcanic_emissions",  # old name: so2
     "day_blowing_snow",
     # "day_cloud_type_distinction",  # aka: day cloud phase distinction
     # "cira_fire_temperature",

--- a/polar2grid/readers/abi_l1b.py
+++ b/polar2grid/readers/abi_l1b.py
@@ -97,7 +97,7 @@ more information on the creation of RGBs, please see the
 +---------------------------+-----------------------------------------------------+
 | day_severe_storms         | Day Severe Storms RGB (aka. Day Convection)         |
 +---------------------------+-----------------------------------------------------+
-| volcanic_emissions_so2    | Volcanic Emissions (SO2 and Ash) (aka. SO2)         |
+| volcanic_emissions        | Volcanic Emissions (SO2 and Ash) (aka. SO2)         |
 +---------------------------+-----------------------------------------------------+
 | day_blowing_snow          | Day Blowing Snow RGB                                |
 +---------------------------+-----------------------------------------------------+
@@ -125,7 +125,7 @@ COMPOSITE_PRODUCTS = [
     # 2025 new
     "day_cloud_type",
     "day_severe_storms",
-    "volanic_emissions_so2",  # old name: so2
+    "volanic_emissions",  # old name: so2
     "day_blowing_snow",
     # "day_cloud_type_distinction",  # aka: day cloud phase distinction
     # "cira_fire_temperature",

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -108,8 +108,8 @@ class FlatBinaryWriter(ImageWriter):
         dst = np.memmap(filename, shape=img.data.shape, dtype=dtype, mode="w+")
         if compute:
             da.store(data, dst)
-            return
-        return [[data], [dst]]
+            return filename
+        return [data], [dst]
 
     def _prep_data(self, data: xr.DataArray, dtype: np.dtype, fill_value) -> da.Array:
         fill = data.attrs.get("_FillValue", np.nan)


### PR DESCRIPTION
Closes #736 

Adds most of the RGBs in some form from the above mentioned issue. Excludes geo_color, sandwich, and day ocean cloud convection.

TODO:

- [ ] Decide on naming
- [ ] Verify output (see related issue for screenshots so far)