### PR TITLE
Change binary writer to use numpy-style dtype names

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,7 @@ Version 3.2.0 (unreleased)
 
 * Change default visible band output to apply '/ cos(SZA)'. Use '--normalized-radiances' for old behavior.
 * Fix resampling coverage calculations
+* Change binary writer output filename "data_type" to numpy-style names (ex. "uint8")
 
 Version 3.1.0 (2024-08-13)
 --------------------------

--- a/polar2grid/core/containers.py
+++ b/polar2grid/core/containers.py
@@ -22,13 +22,6 @@
 # Documentation: http://www.ssec.wisc.edu/software/polar2grid/
 """Classes for metadata operations in polar2grid."""
 
-import logging
-
-import numpy
-from pyproj import Proj
-
-LOG = logging.getLogger(__name__)
-
 
 class GridDefinition(dict):
     """Projected grid defined by a PROJ.4 projection string and other grid parameters.
@@ -56,12 +49,10 @@ class GridDefinition(dict):
     )
 
     def __init__(self, *args, **kwargs):
-        # pyproj.Proj object if needed
-        self.p = None
         if "proj4_definition" in kwargs:
             # pyproj doesn't like unicode
             kwargs["proj4_definition"] = str(kwargs["proj4_definition"])
-        super(GridDefinition, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.validate_keys()
 
     def validate_keys(self):
@@ -81,53 +72,10 @@ class GridDefinition(dict):
         return "\n".join("%s: %s" % (k, self[k]) for k in keys)
 
     @property
-    def proj(self):
-        if self.p is None:
-            self.p = Proj(self["proj4_definition"])
-        return self.p
-
-    @property
     def is_static(self):
         return all(
             [self[x] is not None for x in ["height", "width", "cell_height", "cell_width", "origin_x", "origin_y"]]
         )
-
-    @property
-    def lonlat_lowerleft(self):
-        x_ll, y_ll = self.xy_lowerleft
-        return self.proj(x_ll, y_ll, inverse=True)
-
-    @property
-    def lonlat_lowerright(self):
-        x_ll, y_ll = self.xy_lowerright
-        return self.proj(x_ll, y_ll, inverse=True)
-
-    @property
-    def lonlat_upperright(self):
-        x_ur, y_ur = self.xy_upperright
-        return self.proj(x_ur, y_ur, inverse=True)
-
-    @property
-    def lonlat_upperleft(self):
-        x_ur, y_ur = self["origin_x"], self["origin_y"]
-        return self.proj(x_ur, y_ur, inverse=True)
-
-    @property
-    def lonlat_center(self):
-        x_pixel = self["width"] / 2
-        y_pixel = self["height"] / 2
-        return self.get_lonlat(x_pixel, y_pixel)
-
-    def get_lonlat(self, x_pixel, y_pixel):
-        x = self["origin_x"] + x_pixel * self["cell_width"]
-        y = self["origin_y"] + y_pixel * self["cell_height"]
-        return self.proj(x, y, inverse=True)
-
-    @property
-    def xy_lowerright(self):
-        y_ll = self["origin_y"] + self["cell_height"] * (self["height"] - 1)
-        x_ll = self["origin_x"] + self["cell_width"] * (self["width"] - 1)
-        return x_ll, y_ll
 
     @property
     def xy_lowerleft(self):
@@ -197,83 +145,16 @@ class GridDefinition(dict):
         return proj4_dict
 
     @property
-    def gdal_geotransform(self):
-        # GDAL PixelIsArea (default) geotiffs expects coordinates for the
-        # upper-left corner of the pixel
-        # Polar2Grid and satellite imagery formats assume coordinates for
-        # center of the pixel
-        half_pixel_x = self["cell_width"] / 2.0
-        half_pixel_y = self["cell_height"] / 2.0
-        # cell_height is negative so we need to substract instead of add
-        return (
-            self["origin_x"] - half_pixel_x,
-            self["cell_width"],
-            0,
-            self["origin_y"] - half_pixel_y,
-            0,
-            self["cell_height"],
-        )
-
-    def get_xy_arrays(self):
-        # the [None] indexing adds a dimension to the array
-        x = self["origin_x"] + numpy.repeat(
-            numpy.arange(self["width"])[None] * self["cell_width"], self["height"], axis=0
-        )
-        y = self["origin_y"] + numpy.repeat(
-            numpy.arange(self["height"])[:, None] * self["cell_height"], self["width"], axis=1
-        )
-        return x, y
-
-    def get_geolocation_arrays(self):
-        """Calculate longitude and latitude arrays for the grid.
-
-        :returns: (longitude array, latitude array)
-        """
-        x, y = self.get_xy_arrays()
-        return self.proj(x, y, inverse=True)
-
-    def to_basemap_object(self):
-        from mpl_toolkits.basemap import Basemap
-
-        proj4_dict = self.proj4_dict
-        proj4_dict.pop("no_defs", None)
-        proj4_dict.pop("units", None)
-        proj4_dict["projection"] = proj4_dict.pop("proj")
-
-        if "a" in proj4_dict and "b" in proj4_dict:
-            a = proj4_dict.pop("a")
-            b = proj4_dict.pop("b")
-            proj4_dict["rsphere"] = (a, b)
-        elif "a" in proj4_dict:
-            proj4_dict["rsphere"] = proj4_dict.pop("a")
-        elif "b" in proj4_dict:
-            proj4_dict["rsphere"] = proj4_dict.pop("b")
-
-        lon_ll, lat_ll = self.lonlat_lowerleft
-        lon_ur, lat_ur = self.lonlat_upperright
-        LOG.debug("Passing basemap the following keywords from PROJ.4: %r", proj4_dict)
-        LOG.debug("Lower-left corner: (%f, %f); Upper-right corner: (%f, %f)", lon_ll, lat_ll, lon_ur, lat_ur)
-        return Basemap(llcrnrlon=lon_ll, llcrnrlat=lat_ll, urcrnrlon=lon_ur, urcrnrlat=lat_ur, **proj4_dict)
-
-    @property
     def ll_extent(self):
         xy_ll = self.xy_lowerleft
         # NOTE: cell_height is negative
         return xy_ll[0] - self["cell_width"] / 2.0, xy_ll[1] + self["cell_height"] / 2.0
 
     @property
-    def ll_extent_lonlat(self):
-        return self.proj(*self.ll_extent, inverse=True)
-
-    @property
     def ur_extent(self):
         xy_ur = self.xy_upperright
         # NOTE: cell_height is negative
         return xy_ur[0] + self["cell_width"] / 2.0, xy_ur[1] - self["cell_height"] / 2.0
-
-    @property
-    def ur_extent_lonlat(self):
-        return self.proj(*self.ur_extent, inverse=True)
 
     def to_satpy_area(self):
         from pyresample.geometry import AreaDefinition, DynamicAreaDefinition

--- a/polar2grid/core/dtype.py
+++ b/polar2grid/core/dtype.py
@@ -28,17 +28,6 @@ import numpy as np
 
 log = logging.getLogger(__name__)
 
-DTYPE_UINT8 = "uint1"
-DTYPE_UINT16 = "uint2"
-DTYPE_UINT32 = "uint4"
-DTYPE_UINT64 = "uint8"
-DTYPE_INT8 = "int1"
-DTYPE_INT16 = "int2"
-DTYPE_INT32 = "int4"
-DTYPE_INT64 = "int8"
-DTYPE_FLOAT32 = "real4"
-DTYPE_FLOAT64 = "real8"
-
 NUMPY_DTYPE_STRS = [
     "uint8",
     "uint16",
@@ -52,70 +41,22 @@ NUMPY_DTYPE_STRS = [
     "float64",
 ]
 
-# Map data type to np type for conversion
-str2dtype = {
-    DTYPE_UINT8: np.uint8,
-    DTYPE_UINT16: np.uint16,
-    DTYPE_UINT32: np.uint32,
-    DTYPE_UINT64: np.uint64,
-    DTYPE_INT8: np.int8,
-    DTYPE_INT16: np.int16,
-    DTYPE_INT32: np.int32,
-    DTYPE_INT64: np.int64,
-    DTYPE_FLOAT32: np.float32,
-    DTYPE_FLOAT64: np.float64,
-}
-dtype2str = dict((v, k) for k, v in str2dtype.items())
 
-# Map data type to valid data range
-# Since float32 is polar2grid's intermediate type, float32 and float64 don't
-# get clipped
-dtype2range = {
-    DTYPE_UINT8: (0, 2**8 - 1),
-    DTYPE_UINT16: (0, 2**16 - 1),
-    DTYPE_UINT32: (0, 2**32 - 1),
-    DTYPE_UINT64: (0, 2**64 - 1),
-    DTYPE_INT8: (-1 * (2**7), 2**7 - 1),
-    DTYPE_INT16: (-1 * (2**15), 2**15 - 1),
-    DTYPE_INT32: (-1 * (2**31), 2**31 - 1),
-    DTYPE_INT64: (-1 * (2**63), 2**63 - 1),
-    DTYPE_FLOAT32: None,
-    DTYPE_FLOAT64: None,
-}
-
-
-def normalize_dtype_string(dtype_str):
-    if dtype_str in str2dtype:
-        return dtype_str
-    else:
-        msg = "Unknown data type string '%s'" % (dtype_str,)
-        log.error(msg)
-        raise ValueError(msg)
-
-
-def str_to_dtype(dtype_str):
-    if np.issubclass_(dtype_str, np.number):
-        # if they gave us a np dtype
-        return dtype_str
-    elif isinstance(dtype_str, str) and hasattr(np, dtype_str):
-        # they gave us the np name of the dtype
-        return getattr(np, dtype_str)
-
+def str_to_dtype(dtype_str: str) -> np.dtype:
     try:
-        return str2dtype[dtype_str]
-    except KeyError as err:
+        return getattr(np, dtype_str)
+    except AttributeError:
         raise ValueError("Not a valid data type string: %s" % (dtype_str,)) from err
 
 
-def dtype_to_str(numpy_dtype):
-    if isinstance(numpy_dtype, str):
-        # if they gave us a string, make sure it's valid
-        return normalize_dtype_string(numpy_dtype)
+def dtype_to_str(numpy_dtype: np.dtype | str) -> str:
+    if isinstance(numpy_dtype, str) or not hasattr(numpy_dtype, "name"):
+        numpy_dtype = np.dtype(numpy_dtype)
 
     try:
-        return dtype2str[np.dtype(numpy_dtype).type]
+        return numpy_dtype.name
     except KeyError as err:
-        raise ValueError("Unsupported np data type: %r" % (numpy_dtype,)) from err
+        raise ValueError("Unsupported numpy data type: %r" % (numpy_dtype,)) from err
 
 
 def clip_to_data_type(data, data_type):

--- a/polar2grid/tests/test_dtype.py
+++ b/polar2grid/tests/test_dtype.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Space Science and Engineering Center (SSEC),
+# University of Wisconsin-Madison.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+#     input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+"""Test dtype conversions."""
+
+import numpy as np
+import pytest
+
+from polar2grid.core.dtype import dtype_to_str, str_to_dtype
+
+
+@pytest.mark.parametrize(
+    ("input_arg", "exp_str"),
+    [
+        (np.uint8, "uint8"),
+        ("uint8", "uint8"),
+        ("u1", "uint8"),
+        (np.dtype("uint8"), "uint8"),
+        (np.float32, "float32"),
+        ("float32", "float32"),
+        ("f4", "float32"),
+        (np.dtype("float32"), "float32"),
+        (np.float64, "float64"),
+        ("float64", "float64"),
+        ("f8", "float64"),
+        (np.dtype("float64"), "float64"),
+        (np.int8, "int8"),
+        ("int8", "int8"),
+        ("i1", "int8"),
+        (np.dtype("int8"), "int8"),
+    ],
+)
+def test_dtype_to_str(input_arg, exp_str):
+    """Test conversion from dtype to string."""
+    dtype_str = dtype_to_str(input_arg)
+    assert dtype_str == exp_str
+
+
+@pytest.mark.parametrize(
+    ("input_arg", "exp_dtype"),
+    [
+        ("uint8", np.uint8),
+        ("int8", np.int8),
+        ("float32", np.float32),
+    ],
+)
+def test_str_to_dtype(input_arg, exp_dtype):
+    """Test conversion from string to dtype."""
+    np_dtype = str_to_dtype(input_arg)
+    assert np_dtype == exp_dtype

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -31,6 +31,13 @@ specified using the ``--dtype`` flag. To turn off scaling of the data (a.k.a.
 enhancements) the ``--no-enhance`` command line flag can be specified to write
 the "raw" band data.
 
+.. warning::
+
+   Starting in Polar2Grid 3.3.0, output filename "data_type" fields now follow numpy-style naming.
+   For example, 32-bit floats are now "float32" instead of "real4".
+   Unsigned 8-bit integers are now "uint8" instead of "uint1".
+   The dtype passed to the ``--dtype`` flag is unchanged (numpy style).
+
 """
 
 from __future__ import annotations


### PR DESCRIPTION
If the output filename pattern specified by the user includes "data_type" it now becomes the numpy-style name of the data type. That means instead of the old "real4" you'll get "float32". If the output was for an 8-bit unsigned integer, instead of the old "uint1" it is now "uint8". This was mostly done for consistency and to reduce confusing code in the codebase.