### PR TITLE
Log deprecation warning when legacy '.conf' grid configurations are used

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,7 @@ Version 3.2.0 (unreleased)
 * Change default visible band output to apply '/ cos(SZA)'. Use '--normalized-radiances' for old behavior.
 * Fix resampling coverage calculations
 * Change binary writer output filename "data_type" to numpy-style names (ex. "uint8")
+* Log warning when legacy '.conf' grid configuration files are used
 
 Version 3.1.0 (2024-08-13)
 --------------------------

--- a/polar2grid/resample/_resample_scene.py
+++ b/polar2grid/resample/_resample_scene.py
@@ -96,6 +96,12 @@ def _get_legacy_and_yaml_areas(grid_configs: list[str, ...]) -> tuple[GridManage
     p2g_grid_configs = [x for x in grid_configs if x.endswith(".conf")]
     pyresample_area_configs = [x for x in grid_configs if not x.endswith(".conf")]
     if p2g_grid_configs:
+        configs_str = "\t\n".join(p2g_grid_configs)
+        logger.warning(
+            "Legacy '.conf' grid configuration files are deprecated. Convert "
+            "the following files by using the "
+            f"'convert_grids_conf_to_yaml.sh' script:\n\t{configs_str}"
+        )
         grid_manager = GridManager(*p2g_grid_configs)
     else:
         grid_manager = {}


### PR DESCRIPTION
In future versions `.conf` grid configuration files will not be supported. This PR adds an explicit warning log message so hopefully users convert old configs to the new format in the next release or two.