### PR TITLE
Add --cloud-clear/--no-cloud-clear option to ACSPO reader

### DIFF
--- a/polar2grid/core/script_utils.py
+++ b/polar2grid/core/script_utils.py
@@ -223,6 +223,29 @@ class ExtendConstAction(argparse.Action):
         setattr(namespace, self.dest, current_values)
 
 
+class BooleanFilterAction(argparse.BooleanOptionalAction):
+    """Action to add or not add a filter string to a list of filters."""
+
+    def __init__(self, option_strings, dest, const: str, **kwargs):
+        super().__init__(option_strings, dest, **kwargs)
+        self.const = const
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in self.option_strings:
+            prev = getattr(namespace, self.dest, None)
+            if prev is None:
+                prev = []
+                setattr(namespace, self.dest, prev)
+
+            should_include = not option_string.startswith("--no-")
+            has_const = self.const in prev
+            # modify list inplace
+            if should_include and not has_const:
+                prev.append(self.const)
+            elif not should_include and has_const:
+                prev.remove(self.const)
+
+
 class ArgumentParser(argparse.ArgumentParser):
     def _get_group_actions(self, group):
         """Get all the options/actions in a group including those from subgroups of the provided group.

--- a/polar2grid/readers/acspo.py
+++ b/polar2grid/readers/acspo.py
@@ -50,6 +50,7 @@ from ._base import ReaderProxyBase
 from ..core.script_utils import BooleanFilterAction
 
 DEFAULT_PRODUCTS = ["sst"]
+PREFERRED_CHUNK_SIZE = 2048
 
 
 class ReaderProxy(ReaderProxyBase):

--- a/polar2grid/readers/acspo.py
+++ b/polar2grid/readers/acspo.py
@@ -41,7 +41,7 @@ The ACSPO frontend provides the following products:
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
+from argparse import ArgumentParser, _ArgumentGroup, BooleanOptionalAction
 from typing import Optional
 
 from satpy import DataQuery
@@ -80,34 +80,10 @@ def add_reader_argument_groups(
     """
     if group is None:
         group = parser.add_argument_group(title="AVHRR L1b AAPP Reader")
+    group.add_argument(
+        "--cloud-clear",
+        action=BooleanOptionalAction,
+        default=True,
+        help="Enable or disable cloud clearing for the 'sst' product (default on).",
+    )
     return group, None
-
-
-def add_frontend_argument_groups(parser):
-    """Add command line arguments to an existing parser.
-
-    :returns: list of group titles added
-    """
-    from polar2grid.core.script_utils import ExtendAction
-
-    # Set defaults for other components that may be used in polar2grid processing
-    parser.set_defaults(fornav_D=40, fornav_d=1)
-
-    # Use the append_const action to handle adding products to the list
-    group_title = "Frontend Initialization"
-    group = parser.add_argument_group(title=group_title, description="swath extraction initialization options")
-    group.add_argument(
-        "--list-products", dest="list_products", action="store_true", help="List available frontend products and exit"
-    )
-    group_title = "Frontend Swath Extraction"
-    group = parser.add_argument_group(title=group_title, description="swath extraction options")
-    group.add_argument(
-        "-p",
-        "--products",
-        dest="products",
-        nargs="+",
-        default=None,
-        action=ExtendAction,
-        help="Specify frontend products to process",
-    )
-    return ["Frontend Initialization", "Frontend Swath Extraction"]

--- a/polar2grid/readers/acspo.py
+++ b/polar2grid/readers/acspo.py
@@ -41,12 +41,13 @@ The ACSPO frontend provides the following products:
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup, BooleanOptionalAction
+from argparse import ArgumentParser, _ArgumentGroup
 from typing import Optional
 
 from satpy import DataQuery
 
 from ._base import ReaderProxyBase
+from ..core.script_utils import BooleanFilterAction
 
 DEFAULT_PRODUCTS = ["sst"]
 
@@ -82,8 +83,10 @@ def add_reader_argument_groups(
         group = parser.add_argument_group(title="AVHRR L1b AAPP Reader")
     group.add_argument(
         "--cloud-clear",
-        action=BooleanOptionalAction,
-        default=True,
+        action=BooleanFilterAction,
+        dest="filters",
+        const="cloud_clear",
+        default=["cloud_clear"],
         help="Enable or disable cloud clearing for the 'sst' product (default on).",
     )
     return group, None


### PR DESCRIPTION
This was previously always enabled and not user-controllable. Now there's a flag. Default is the same behavior.

Similar, but different flag, to #758.