### PR TITLE
Remove '--fix-awips' flag

### DIFF
--- a/polar2grid/glue.py
+++ b/polar2grid/glue.py
@@ -274,7 +274,7 @@ def _create_profile_html_if(create_profile: Union[False, None, str], project_nam
         end_time=end_time,
     )
     profile_filename = os.path.abspath(profile_filename)
-    visualize([prof, rprof, cprof], file_path=profile_filename, show=False)
+    visualize([prof, rprof, cprof], filename=profile_filename, show=False)
     print(f"Profile HTML: file://{profile_filename}")
 
 

--- a/polar2grid/writers/awips_tiled.py
+++ b/polar2grid/writers/awips_tiled.py
@@ -108,7 +108,6 @@ def add_writer_argument_groups(parser, group=None):
     # group_1.add_argument('--file-pattern', default=DEFAULT_OUTPUT_PATTERN,
     #                      help="Custom file pattern to save dataset to")
     group.add_argument("--compress", action="store_true", help="zlib compress each netcdf file")
-    group.add_argument("--fix-awips", action="store_true", help=argparse.SUPPRESS)
     # help="modify NetCDF output to work with the old/broken AWIPS NetCDF library")
     group.add_argument(
         "--output-filename",


### PR DESCRIPTION
I removed support for this from Satpy as it isn't needed in modern AWIPS.

This PR also includes fixing a deprecated keyword argument for dask's `visualize` diagnostics function.