### PR TITLE
Add mocking to all pyspectral downloads in tests

### DIFF
--- a/polar2grid/tests/conftest.py
+++ b/polar2grid/tests/conftest.py
@@ -83,15 +83,6 @@ def ensure_logging_framework_not_altered():
     root_logger.handlers = before_handlers
 
 
-# @pytest.mark.fixture(autouse=True, scope="session")
-# def _mock_pyspectral(tmp_path_factory):
-#     from pyspectral.testing import mock_pyspectral_downloads
-#
-#     tmp_path = tmp_path_factory.mktemp("pyspectral_fake_root_")
-#     with mock_pyspectral_downloads(tmp_path=tmp_path):
-#         yield
-
-
 @pytest.fixture(autouse=True, scope="session")
 def _forbid_pyspectral_downloads():
     from pyspectral.testing import forbid_pyspectral_downloads


### PR DESCRIPTION
~Our CI has been downloading pyspectral LUTs *every* time they execute. Very wasteful in many ways.~ New utilities from pyspectral make it very simple to mock all of this downloading.

Update: I was wrong. I'm mocking the entire Satpy Scene so it never even reached pyspectral to do a download. This PR now only forbids downloading which should catch any future tests triggering pyspectral's downloads.