### PR TITLE
Add support for VIIRS EDR Cryosphere (IceAge/IceConcentration) files

### DIFF
--- a/polar2grid/etc/enhancements/viirs.yaml
+++ b/polar2grid/etc/enhancements/viirs.yaml
@@ -338,7 +338,7 @@ enhancements:
         kwargs:
           palettes:
             - min_value: 0.0
-              max_value: 6.0
+              max_value: 3.0
               colors: "rainbow"
 
   iceconc:
@@ -361,6 +361,6 @@ enhancements:
         method: !!python/name:polar2grid.enhancements.shared.colorize
         kwargs:
           palettes:
-            - min_value: 100.0
-              max_value: 390.0
+            - min_value: 230.0
+              max_value: 275.0
               colors: "rainbow"

--- a/polar2grid/etc/enhancements/viirs.yaml
+++ b/polar2grid/etc/enhancements/viirs.yaml
@@ -316,3 +316,51 @@ enhancements:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs: { stretch: 'crude', min_stretch: -1.0, max_stretch: 1.0 }
+
+  iceage:
+    name: IceAge
+    sensor: viirs
+    operations:
+      - name: colorize
+        method: !!python/name:polar2grid.enhancements.shared.colorize
+        kwargs:
+          palettes:
+            - min_value: 1.0
+              max_value: 8.0
+              colors: "rainbow"
+
+  icethickness:
+    name: IceThickness
+    sensor: viirs
+    operations:
+      - name: colorize
+        method: !!python/name:polar2grid.enhancements.shared.colorize
+        kwargs:
+          palettes:
+            - min_value: 0.0
+              max_value: 6.0
+              colors: "rainbow"
+
+  iceconc:
+    name: IceConc
+    sensor: viirs
+    operations:
+      - name: colorize
+        method: !!python/name:polar2grid.enhancements.shared.colorize
+        kwargs:
+          palettes:
+            - min_value: 0.0
+              max_value: 100.0
+              colors: "rainbow"
+
+  icesrftemp:
+    name: IceSrfTemp
+    sensor: viirs
+    operations:
+      - name: colorize
+        method: !!python/name:polar2grid.enhancements.shared.colorize
+        kwargs:
+          palettes:
+            - min_value: 100.0
+              max_value: 390.0
+              colors: "rainbow"

--- a/polar2grid/etc/resampling.yaml
+++ b/polar2grid/etc/resampling.yaml
@@ -86,22 +86,6 @@ resampling:
     kwargs:
       weight_delta_max: 40.0
       weight_distance_max: 2.0
-  default_viirs_edr:
-    area_type: swath
-    sensor: viirs
-    reader: viirs_edr
-    resampler: ewa
-    kwargs:
-      weight_delta_max: 40.0
-      weight_distance_max: 2.0
-  default_viirs_edr:
-    area_type: swath
-    sensor: viirs
-    reader: viirs_edr
-    resampler: ewa
-    kwargs:
-      weight_delta_max: 40.0
-      weight_distance_max: 2.0
   default_nucaps:
     area_type: swath
     reader: nucaps
@@ -267,6 +251,24 @@ resampling:
     name: CloudLayer
     reader: viirs_edr
     area_type: swath
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 2.0
+      maximum_weight_mode: true
+  viirs_edr:
+    area_type: swath
+    sensor: viirs
+    reader: viirs_edr
+    resampler: ewa
+    kwargs:
+      weight_delta_max: 40.0
+      weight_distance_max: 2.0
+  viirs_edr_iceage:
+    name: IceAge
+    area_type: swath
+    sensor: viirs
+    reader: viirs_edr
     resampler: ewa
     kwargs:
       weight_delta_max: 40.0

--- a/polar2grid/readers/viirs_edr.py
+++ b/polar2grid/readers/viirs_edr.py
@@ -114,6 +114,12 @@ OTHER_PRODS = [
     "CldBaseHght",
     "Total_Cloud_Fraction",
     "CloudLayer",
+    # IceAge variables:
+    "IceAge",
+    "IceThickness",
+    # IceConcentration variables:
+    "IceConc",
+    "IceSrfTemp",
 ]
 
 PRODUCT_ALIASES = {}


### PR DESCRIPTION
Closes #807 

@kathys thoughts on these screenshots:

### IceAge

<img width="2428" height="746" alt="image" src="https://github.com/user-attachments/assets/a4af14b1-2abc-4c3c-8a9b-7a1b575f8557" />

### IceThickness

<img width="2427" height="741" alt="image" src="https://github.com/user-attachments/assets/5c23532f-d836-48ac-aebd-93a24a56507b" />

### IceConc

<img width="2425" height="745" alt="image" src="https://github.com/user-attachments/assets/53ccf283-b5b2-43a5-9836-8bf5182e7265" />

### IceSrfTemp

<img width="2419" height="739" alt="image" src="https://github.com/user-attachments/assets/7ebdb38f-8589-48a1-8d09-a773ba580998" />

Only thing I noticed is on the JSTAR Mapper site the IceConc starts at 1% on the colorbar. Not sure that makes a big enough difference to not include the values from 0% to 1%.