### PR TITLE
Add initial VIIRS S3 search script

### DIFF
--- a/create_conda_software_bundle.sh
+++ b/create_conda_software_bundle.sh
@@ -94,6 +94,7 @@ if [[ $PROJECT == "P2G" ]]; then
     cp $BASE_P2G_DIR/NEWS.rst $SB_NAME/RELEASE_NOTES.txt || oops "Couldn't copy release notes to destination directory"
 else
     rm -f bin/polar2grid.sh
+    rm -f bin/search_noaa_s3_viirs.sh
     rm -f bin/POLAR2GRID_README.txt
     mv bin/GEO2GRID_README.txt README.txt
     cp $BASE_P2G_DIR/NEWS_GEO2GRID.rst $SB_NAME/RELEASE_NOTES.txt || oops "Couldn't copy release notes to destination directory"

--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -127,6 +127,13 @@ class GlueArgumentParser:
         self._args = parser.parse_args(argv)
         _validate_reader_writer_args(parser, self._args, self._is_polar2grid)
 
+        if self._args.filenames == ["-"]:
+            # parse filenames from stdin
+            self._args.filenames = [line.rstrip("\n") for line in sys.stdin]
+        if not self._args.filenames:
+            parser.print_usage()
+            parser.exit(1, "\nERROR: No data files provided (-f flag)\n")
+
         self._reader_args = _args_to_dict(self._args, reader_group._group_actions)
         self._reader_names = self._reader_args.pop("readers")
         self._separate_scene_init_load_args(reader_subgroups)
@@ -134,10 +141,6 @@ class GlueArgumentParser:
         self._writer_args = _args_to_dict(self._args, writer_group._group_actions)
         writer_specific_args = self._parse_one_writer_args(writer_subgroups)
         self._writer_args.update(writer_specific_args)
-
-        if not self._args.filenames:
-            parser.print_usage()
-            parser.exit(1, "\nERROR: No data files provided (-f flag)\n")
 
     def _separate_scene_init_load_args(self, reader_subgroups) -> None:
         products = self._reader_args.pop("products") or []
@@ -207,7 +210,6 @@ basic processing with limited products:
     parser = argparse.ArgumentParser(
         prog=prog,
         usage=usage,
-        fromfile_prefix_chars="@",
         description="Load, composite, resample, and save datasets.",
     )
     _add_common_arguments(parser, binary_name)
@@ -218,6 +220,10 @@ basic processing with limited products:
 
     _retitle_optional_arguments(parser)
     args, _ = parser.parse_known_args(argv_without_help)
+    # we didn't parse fromfile arguments before, but we will next time so enable it now
+    # NOTE: This means that if @ is used for arguments that require a specific number of arguments
+    #       or for arguments themselves, they won't be parsed until next time.
+    parser.fromfile_prefix_chars = "@"
     return parser, args, reader_group, resampling_group, writer_group
 
 

--- a/polar2grid/etc/composites/viirs.yaml
+++ b/polar2grid/etc/composites/viirs.yaml
@@ -283,13 +283,13 @@ composites:
     - M15
     standard_name: overview
 
-  night_microphysics:
-    compositor: !!python/name:satpy.composites.core.GenericCompositor
-    prerequisites:
-    - DNB
-    - M12
-    - M15
-    standard_name: night_microphysics
+#  night_microphysics:
+#    compositor: !!python/name:satpy.composites.core.GenericCompositor
+#    prerequisites:
+#    - DNB
+#    - M12
+#    - M15
+#    standard_name: night_microphysics
 
   ifog:
     compositor: !!python/name:satpy.composites.arithmetic.DifferenceCompositor

--- a/polar2grid/utils/search_noaa_s3_viirs.py
+++ b/polar2grid/utils/search_noaa_s3_viirs.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Glob for VIIRS SDR objects in NOAA NESDIS S3 buckets.
+
+Example usage:
+  # Single band
+  python glob_viirs_s3.py --satellite n20 --band I05 \
+      --start-time 2026-04-24T01:10 --end-time 2026-04-24T01:12
+
+  # Multiple bands
+  python glob_viirs_s3.py --satellite n20 --band I04 --band I05 --band M15 \
+      --start-time 2026-04-24T00:00 --end-time 2026-04-24T01:00
+
+  # All bands
+  python glob_viirs_s3.py --satellite n20 --band ALL \
+      --start-time 2026-04-24T00:00 --end-time 2026-04-24T23:59 \
+      --no-sign-request
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections.abc import Iterable, Iterator
+from datetime import datetime, timedelta, timezone
+
+import s3fs
+
+BUCKET_FORMAT_STR = os.environ.get("BUCKET_FORMAT_STR", "noaa-nesdis-{satellite}-pds")
+GRANULE_DURATION_SECONDS = 90
+
+# ---------------------------------------------------------------------------
+# Band helpers
+# ---------------------------------------------------------------------------
+
+VALID_BANDS = (
+    ["I01", "I02", "I03", "I04", "I05"]
+    + [f"M{n:02d}" for n in range(1, 17)]
+    # non-terrain corrected geolocation is not available from NOAA buckets
+    + ["DNB", "GITCO", "GMTCO", "GDNBO"]  # + ["GIMGO", "GMODO"]
+)
+DEFAULT_BANDS = VALID_BANDS
+
+# Special token accepted by --band that expands to every band
+ALL_BANDS_TOKEN = "ALL"
+
+
+def parse_band(value: str) -> list[str]:
+    """Validate a single --band value and return the list of bands it represents.
+
+    "ALL" expands to every band; otherwise the value must be a known band name.
+
+    """
+    upper = value.upper()
+    if upper == ALL_BANDS_TOKEN:
+        return list(DEFAULT_BANDS)
+    if upper not in VALID_BANDS:
+        raise argparse.ArgumentTypeError(
+            f"Invalid band {value!r}. Choose from {', '.join(VALID_BANDS)} or '{ALL_BANDS_TOKEN}'."
+        )
+    return [upper]
+
+
+def band_to_prefix(band: str) -> str:
+    """Convert a band name to the SDR product-prefix segment used in the S3 key.
+
+    I01 -> I1   I05 -> I5
+    M01 -> M1   M16 -> M16
+    DNB -> DNB
+
+    GITCO -> GITCO   GMTCO -> GMTCO
+    GDNBO -> GDNBO
+    """
+    if band.startswith("G"):
+        # M-band and I-band geolocation are only available for terrain-corrected (TC)
+        band_type = "GEO" if band[1] == "D" else "GEO-TC"
+    else:
+        band_type = "SDR"
+
+    if band == "DNB":
+        prefix_id = band
+    elif band[0] == "G":
+        prefix_id = {
+            "D": "DNB",
+            "I": "IMG",
+            "M": "MOD",
+        }[band[1]]
+    else:
+        letter = band[0]  # 'I' or 'M'
+        number = int(band[1:])  # strip leading zero
+        prefix_id = f"{letter}{number}"
+
+    return f"VIIRS-{prefix_id}-{band_type}"
+
+
+# ---------------------------------------------------------------------------
+# Date/time helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_datetime(s: str) -> datetime:
+    """Parse date/times from the command line.
+
+    Accept ISO-8601-ish strings: YYYY-MM-DDTHH:MM[:SS]
+
+    """
+    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    raise argparse.ArgumentTypeError(f"Cannot parse datetime {s!r}. Use YYYY-MM-DDTHH:MM[:SS] or YYYY-MM-DD.")
+
+
+def iter_day_prefixes(start: datetime, end: datetime):
+    """Yield every unique YYYY/MM/DD string between start and end (inclusive)."""
+    day = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    if (start - day).total_seconds() < GRANULE_DURATION_SECONDS:
+        # if we might get a partial granule on the midnight boundary, then search the previous day
+        day = day - timedelta(days=1)
+    end_day = end.replace(hour=0, minute=0, second=0, microsecond=0)
+    if ((end_day + timedelta(days=1)) - end).total_seconds() < GRANULE_DURATION_SECONDS:
+        # if we might get a partial granule on the end of the day over midnight then search the next day too
+        end_day = end_day + timedelta(days=1)
+    while day <= end_day:
+        yield day.strftime("%Y/%m/%d")
+        day += timedelta(days=1)
+
+
+# ---------------------------------------------------------------------------
+# Filename time extraction
+# ---------------------------------------------------------------------------
+
+_FNAME_RE = re.compile(
+    r"_d(?P<date>\d{8})"  # dYYYYMMDD
+    r"_t(?P<tstart>\d{7})"  # tHHMMSSd  (tenths digit after seconds)
+    r"_e(?P<tend>\d{7})"  # eHHMMSSd
+)
+
+
+def file_start_time(filename: str) -> datetime | None:
+    """Parse the granule start time from a VIIRS SDR filename."""
+    m = _FNAME_RE.search(filename)
+    if not m:
+        return None
+    date_str = m.group("date")  # YYYYMMDD
+    tstart = m.group("tstart")[:6]  # HHMMSS (drop tenths digit)
+    try:
+        return datetime.strptime(date_str + tstart, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def file_end_time(filename: str) -> datetime | None:
+    """Parse the granule end time from a VIIRS SDR filename."""
+    m = _FNAME_RE.search(filename)
+    if not m:
+        return None
+    date_str = m.group("date")
+    tend = m.group("tend")[:6]
+    try:
+        dt = datetime.strptime(date_str + tend, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+        # Granules that cross midnight: end time can be earlier than start
+        # on the same calendar day -- advance by one day when that happens.
+        tstart = file_start_time(filename)
+        if tstart and dt < tstart:
+            dt += timedelta(days=1)
+        return dt
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Glob VIIRS SDR files in a NOAA NESDIS public S3 bucket.")
+    p.add_argument(
+        "-s",
+        "--satellite",
+        required=True,
+        help="Satellite identifier, e.g. n20, n21, snpp.",
+    )
+    p.add_argument(
+        "-b",
+        "--band",
+        required=True,
+        action="append",
+        dest="bands",
+        type=parse_band,
+        metavar="BAND",
+        help=(
+            "VIIRS band to search for. May be specified multiple times. "
+            f"Individual choices: {', '.join(VALID_BANDS)}. "
+            f"Use '{ALL_BANDS_TOKEN}' to select every band plus terrain-corrected geolocation."
+        ),
+    )
+    p.add_argument(
+        "--start-time",
+        required=True,
+        type=parse_datetime,
+        metavar="YYYY-MM-DDTHH:MM[:SS]",
+        help="Earliest granule start time (UTC).",
+    )
+    p.add_argument(
+        "--end-time",
+        required=True,
+        type=parse_datetime,
+        metavar="YYYY-MM-DDTHH:MM[:SS]",
+        help="Latest granule end time (UTC).",
+    )
+    p.add_argument(
+        "--profile",
+        default=None,
+        help="AWS profile name to use for authenticated access.",
+    )
+    p.add_argument(
+        "--print-urls",
+        action="store_true",
+        help="Print HTTPS URLs instead of s3:// paths.",
+    )
+    return p
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.start_time > args.end_time:
+        parser.error("--start-time must be before --end-time")
+    if (args.end_time - args.start_time).total_seconds() >= 60 * 60:
+        parser.error("Time range can't be more than 60 minutes.")
+
+    # Flatten the list-of-lists produced by action="append" + type=parse_band,
+    # then deduplicate while preserving the canonical VALID_BANDS order.
+    requested = {band for group in args.bands for band in group}
+    bands = [b for b in VALID_BANDS if b in requested]
+    satellite = args.satellite.lower()
+
+    if args.profile is None:
+        fs = s3fs.S3FileSystem(anon=True)
+    else:
+        fs = s3fs.S3FileSystem(anon=False, profile=args.profile)
+
+    found = []
+    for glob_pattern in _generate_glob_patterns(bands, args.start_time, args.end_time, satellite):
+        try:
+            # TODO: Use fs.find and then filter with glob/fnmatch. Might be faster
+            matches = fs.glob(glob_pattern)
+        except FileNotFoundError:
+            # Prefix doesn't exist yet -- no data for that day/band
+            continue
+        except Exception as exc:
+            print(f"Warning: error listing {glob_pattern}: {exc}", file=sys.stderr)
+            continue
+
+        found.extend(_filter_by_start_end(matches, args.start_time, args.end_time))
+
+    if not found:
+        print("No matching objects found.", file=sys.stderr)
+        sys.exit(1)
+
+    for path in sorted(found):
+        if args.print_urls:
+            # s3://bucket/key  ->  https://bucket.s3.amazonaws.com/key
+            parts = path.split("/", 1)
+            bkt, key = parts[0], parts[1] if len(parts) > 1 else ""
+            print(f"https://{bkt}.s3.amazonaws.com/{key}")
+        else:
+            print(f"s3://{path}")
+
+
+def _generate_glob_patterns(
+    bands: Iterable[str], start_time: datetime, end_time: datetime, satellite: str
+) -> Iterator[str]:
+    fn_platform = {
+        "snpp": "npp",
+        "n20": "j01",
+        "n21": "j02",
+        "n22": "j03",
+        "n23": "j04",
+    }[satellite]
+    bucket = BUCKET_FORMAT_STR.format(satellite=satellite)
+
+    for band in bands:
+        prefix_code = band_to_prefix(band)  # e.g. "I5", "M3", "DNB"
+        fn_band_id = f"SV{band}" if band[0] in ("M", "I", "D") else band
+
+        for day_path in iter_day_prefixes(start_time, end_time):
+            # e.g. noaa-nesdis-n20-pds/VIIRS-I5-SDR/2026/04/24/
+            prefix = f"{bucket}/{prefix_code}/{day_path}/"
+            fn_day_str = day_path.replace("/", "")
+            # TODO: Also iterate by hour, half orbit is ~51 minutes
+            glob_pattern = f"{prefix}{fn_band_id}_{fn_platform}_d{fn_day_str}_t*.h5"
+            yield glob_pattern
+
+
+def _filter_by_start_end(possible_paths: Iterable[str], start_time: datetime, end_time: datetime) -> Iterator[str]:
+    for path in possible_paths:
+        fname = path.rsplit("/", 1)[-1]
+        t_start = file_start_time(fname)
+        t_end = file_end_time(fname)
+
+        # Filter: granule must overlap [args.start_time, args.end_time]
+        if t_start is not None and t_end is not None:
+            if t_end < start_time or t_start > end_time:
+                continue
+        elif t_start is not None:
+            if t_start > end_time:
+                continue
+
+        yield path
+
+
+if __name__ == "__main__":
+    main()

--- a/polar2grid/utils/search_noaa_s3_viirs.py
+++ b/polar2grid/utils/search_noaa_s3_viirs.py
@@ -19,6 +19,7 @@ Example usage:
 from __future__ import annotations
 
 import argparse
+from glob import fnmatch
 import os
 import re
 import sys
@@ -63,14 +64,11 @@ def parse_band(value: str) -> list[str]:
 
 
 def band_to_prefix(band: str) -> str:
-    """Convert a band name to the SDR product-prefix segment used in the S3 key.
+    """Convert a band name to the SDR or GEO product-prefix segment used in the S3 key.
 
-    I01 -> I1   I05 -> I5
-    M01 -> M1   M16 -> M16
-    DNB -> DNB
+    For example, the I01 SDR band is converted to "VIIRS-I1-SDR". The geolocation
+    "band" GITCO is converted to "VIIRS-IMG-GEO-TC".
 
-    GITCO -> GITCO   GMTCO -> GMTCO
-    GDNBO -> GDNBO
     """
     if band.startswith("G"):
         # M-band and I-band geolocation are only available for terrain-corrected (TC)
@@ -114,18 +112,19 @@ def parse_datetime(s: str) -> datetime:
 
 
 def iter_day_prefixes(start: datetime, end: datetime):
-    """Yield every unique YYYY/MM/DD string between start and end (inclusive)."""
-    day = start.replace(hour=0, minute=0, second=0, microsecond=0)
-    if (start - day).total_seconds() < GRANULE_DURATION_SECONDS:
-        # if we might get a partial granule on the midnight boundary, then search the previous day
-        day = day - timedelta(days=1)
-    end_day = end.replace(hour=0, minute=0, second=0, microsecond=0)
-    if ((end_day + timedelta(days=1)) - end).total_seconds() < GRANULE_DURATION_SECONDS:
-        # if we might get a partial granule on the end of the day over midnight then search the next day too
-        end_day = end_day + timedelta(days=1)
-    while day <= end_day:
-        yield day.strftime("%Y/%m/%d")
-        day += timedelta(days=1)
+    """Yield every unique date/time between start and end (inclusive) at hour resolution."""
+    curr_time = start.replace(minute=0, second=0, microsecond=0)
+    if start.hour == 0 and (start - curr_time).total_seconds() < GRANULE_DURATION_SECONDS:
+        # if we might get a partial granule on the midnight boundary, then search the 23rd hour of the previous day
+        curr_time = curr_time - timedelta(hours=1)
+    end_day = end.replace(minute=0, second=0, microsecond=0)
+    if end_day.hour == 23 and ((end_day + timedelta(hours=1)) - end).total_seconds() < GRANULE_DURATION_SECONDS:
+        # if we might get a partial granule on the end of the day over midnight
+        # then search the first hour of the next day
+        end_day = end_day + timedelta(hours=1)
+    while curr_time <= end_day:
+        yield curr_time
+        curr_time += timedelta(hours=1)
 
 
 # ---------------------------------------------------------------------------
@@ -247,17 +246,9 @@ def main():
 
     found = []
     for glob_pattern in _generate_glob_patterns(bands, args.start_time, args.end_time, satellite):
-        try:
-            # TODO: Use fs.find and then filter with glob/fnmatch. Might be faster
-            matches = fs.glob(glob_pattern)
-        except FileNotFoundError:
-            # Prefix doesn't exist yet -- no data for that day/band
-            continue
-        except Exception as exc:
-            print(f"Warning: error listing {glob_pattern}: {exc}", file=sys.stderr)
-            continue
-
-        found.extend(_filter_by_start_end(matches, args.start_time, args.end_time))
+        print(f"Glob pattern: {glob_pattern=}", file=sys.stderr)
+        glob_matches = _glob_s3_fs(fs, glob_pattern)
+        found.extend(_filter_by_start_end(glob_matches, args.start_time, args.end_time))
 
     if not found:
         print("No matching objects found.", file=sys.stderr)
@@ -289,13 +280,31 @@ def _generate_glob_patterns(
         prefix_code = band_to_prefix(band)  # e.g. "I5", "M3", "DNB"
         fn_band_id = f"SV{band}" if band[0] in ("M", "I", "D") else band
 
-        for day_path in iter_day_prefixes(start_time, end_time):
+        for glob_datetime in iter_day_prefixes(start_time, end_time):
+            day_path = glob_datetime.strftime("%Y/%m/%d")
+            fn_day_str = day_path.replace("/", "")
+            fn_time_hour = glob_datetime.strftime("%H")
             # e.g. noaa-nesdis-n20-pds/VIIRS-I5-SDR/2026/04/24/
             prefix = f"{bucket}/{prefix_code}/{day_path}/"
-            fn_day_str = day_path.replace("/", "")
-            # TODO: Also iterate by hour, half orbit is ~51 minutes
-            glob_pattern = f"{prefix}{fn_band_id}_{fn_platform}_d{fn_day_str}_t*.h5"
+            # later process (see _glob_s3_fs) is very particular about how many wildcards are used
+            glob_pattern = f"{prefix}{fn_band_id}_{fn_platform}_d{fn_day_str}_t{fn_time_hour}*.h5"
             yield glob_pattern
+
+
+def _glob_s3_fs(fs: s3fs.S3FileSystem, glob_pattern: str) -> Iterator[str]:
+    # At the time of writing fs.glob is slow because it iterates over all
+    # objects in the bucket instead of using a prefix
+    # yield from fs.glob(glob_pattern)
+    # return
+
+    uri_path, uri_fn = glob_pattern.rsplit("/", 1)
+    uri_fn = uri_fn.rstrip("/")
+    static_fn_prefix = uri_fn.split("*", 1)[0]
+    for result in fs.find(uri_path, prefix=static_fn_prefix):
+        res_fn = result.rsplit("/", 1)[1]
+        if not fnmatch.fnmatch(res_fn, uri_fn):
+            continue
+        yield result
 
 
 def _filter_by_start_end(possible_paths: Iterable[str], start_time: datetime, end_time: datetime) -> Iterator[str]:

--- a/polar2grid/utils/search_noaa_s3_viirs.py
+++ b/polar2grid/utils/search_noaa_s3_viirs.py
@@ -138,44 +138,29 @@ _FNAME_RE = re.compile(
 )
 
 
-def file_start_time(filename: str) -> datetime | None:
+def file_start_end_time(filename: str) -> tuple[datetime, datetime] | tuple[None, None]:
     """Parse the granule start time from a VIIRS SDR filename."""
-    m = _FNAME_RE.search(filename)
-    if not m:
+    if (m := _FNAME_RE.search(filename)) is None:
         print(f"Unexpected filename scheme discovered: {filename}", file=sys.stderr)
-        return None
-    date_str = m.group("date")  # YYYYMMDD
-    tstart = m.group("tstart")[:6]  # HHMMSS (drop tenths digit)
+        return None, None
+
     try:
-        return datetime.strptime(date_str + tstart, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+        return _convert_file_times_to_datetimes(
+            m.group("date"),  # YYYYMMDD
+            m.group("tstart")[:6],  # HHMMSS (drop microseconds)
+            m.group("tend")[:6],
+        )
     except ValueError:
         print(f"Could not parse time information: {filename}", file=sys.stderr)
-        return None
+        return None, None
 
 
-def file_end_time(filename: str) -> datetime | None:
-    """Parse the granule end time from a VIIRS SDR filename."""
-    m = _FNAME_RE.search(filename)
-    if not m:
-        return None
-    date_str = m.group("date")
-    tend = m.group("tend")[:6]
-    try:
-        dt = datetime.strptime(date_str + tend, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
-        # Granules that cross midnight: end time can be earlier than start
-        # on the same calendar day -- advance by one day when that happens.
-        tstart = file_start_time(filename)
-        if tstart and dt < tstart:
-            dt += timedelta(days=1)
-        return dt
-    except ValueError:
-        print(f"Could not parse time information: {filename}", file=sys.stderr)
-        return None
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
+def _convert_file_times_to_datetimes(date_str: str, tstart: str, tend: str) -> tuple[datetime, datetime]:
+    start_dt = datetime.strptime(date_str + tstart, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+    end_dt = datetime.strptime(date_str + tend, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+    if end_dt < start_dt:
+        end_dt += timedelta(days=1)
+    return start_dt, end_dt
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -295,14 +280,14 @@ def _glob_s3_fs(fs: s3fs.S3FileSystem, glob_pattern: str) -> Iterator[str]:
 def _filter_by_start_end(possible_paths: Iterable[str], start_time: datetime, end_time: datetime) -> Iterator[str]:
     for path in possible_paths:
         fname = path.rsplit("/", 1)[-1]
-        if (t_start := file_start_time(fname)) is None:
-            continue
-        if (t_end := file_end_time(fname)) is None:
-            continue
-        if t_end < start_time or t_start > end_time:
-            continue
+        if _overlaps_time_range(fname, start_time, end_time):
+            yield path
 
-        yield path
+
+def _overlaps_time_range(fname: str, start_time: datetime, end_time: datetime) -> bool:
+    t_start, t_end = file_start_end_time(fname)
+
+    return t_start is not None and t_end is not None and not (t_end < start_time or t_start > end_time)
 
 
 def _print_uris(paths: Iterable[str], print_urls: bool) -> None:

--- a/polar2grid/utils/search_noaa_s3_viirs.py
+++ b/polar2grid/utils/search_noaa_s3_viirs.py
@@ -142,12 +142,14 @@ def file_start_time(filename: str) -> datetime | None:
     """Parse the granule start time from a VIIRS SDR filename."""
     m = _FNAME_RE.search(filename)
     if not m:
+        print(f"Unexpected filename scheme discovered: {filename}", file=sys.stderr)
         return None
     date_str = m.group("date")  # YYYYMMDD
     tstart = m.group("tstart")[:6]  # HHMMSS (drop tenths digit)
     try:
         return datetime.strptime(date_str + tstart, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
     except ValueError:
+        print(f"Could not parse time information: {filename}", file=sys.stderr)
         return None
 
 
@@ -167,6 +169,7 @@ def file_end_time(filename: str) -> datetime | None:
             dt += timedelta(days=1)
         return dt
     except ValueError:
+        print(f"Could not parse time information: {filename}", file=sys.stderr)
         return None
 
 
@@ -212,11 +215,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Latest granule end time (UTC).",
     )
     p.add_argument(
-        "--profile",
-        default=None,
-        help="AWS profile name to use for authenticated access.",
-    )
-    p.add_argument(
         "--print-urls",
         action="store_true",
         help="Print HTTPS URLs instead of s3:// paths.",
@@ -239,29 +237,16 @@ def main():
     bands = [b for b in VALID_BANDS if b in requested]
     satellite = args.satellite.lower()
 
-    if args.profile is None:
-        fs = s3fs.S3FileSystem(anon=True)
-    else:
-        fs = s3fs.S3FileSystem(anon=False, profile=args.profile)
-
+    fs = s3fs.S3FileSystem(anon=True)
     found = []
     for glob_pattern in _generate_glob_patterns(bands, args.start_time, args.end_time, satellite):
-        print(f"Glob pattern: {glob_pattern=}", file=sys.stderr)
         glob_matches = _glob_s3_fs(fs, glob_pattern)
         found.extend(_filter_by_start_end(glob_matches, args.start_time, args.end_time))
 
     if not found:
         print("No matching objects found.", file=sys.stderr)
         sys.exit(1)
-
-    for path in sorted(found):
-        if args.print_urls:
-            # s3://bucket/key  ->  https://bucket.s3.amazonaws.com/key
-            parts = path.split("/", 1)
-            bkt, key = parts[0], parts[1] if len(parts) > 1 else ""
-            print(f"https://{bkt}.s3.amazonaws.com/{key}")
-        else:
-            print(f"s3://{path}")
+    _print_uris(found, args.print_urls)
 
 
 def _generate_glob_patterns(
@@ -310,18 +295,25 @@ def _glob_s3_fs(fs: s3fs.S3FileSystem, glob_pattern: str) -> Iterator[str]:
 def _filter_by_start_end(possible_paths: Iterable[str], start_time: datetime, end_time: datetime) -> Iterator[str]:
     for path in possible_paths:
         fname = path.rsplit("/", 1)[-1]
-        t_start = file_start_time(fname)
-        t_end = file_end_time(fname)
-
-        # Filter: granule must overlap [args.start_time, args.end_time]
-        if t_start is not None and t_end is not None:
-            if t_end < start_time or t_start > end_time:
-                continue
-        elif t_start is not None:
-            if t_start > end_time:
-                continue
+        if (t_start := file_start_time(fname)) is None:
+            continue
+        if (t_end := file_end_time(fname)) is None:
+            continue
+        if t_end < start_time or t_start > end_time:
+            continue
 
         yield path
+
+
+def _print_uris(paths: Iterable[str], print_urls: bool) -> None:
+    for path in paths:
+        if print_urls:
+            # s3://bucket/key  ->  https://bucket.s3.amazonaws.com/key
+            parts = path.split("/", 1)
+            bkt, key = parts[0], parts[1] if len(parts) > 1 else ""
+            print(f"https://{bkt}.s3.amazonaws.com/{key}")
+        else:
+            print(f"s3://{path}")
 
 
 if __name__ == "__main__":

--- a/swbundle/geo2grid.sh
+++ b/swbundle/geo2grid.sh
@@ -39,4 +39,4 @@ export OMP_NUM_THREADS=${OMP_NUM_THREADS:-2}
 # Call the python module to do the processing, passing all arguments
 export PROG_NAME="geo2grid.sh"
 export USE_POLAR2GRID_DEFAULTS=0
-python3 -m polar2grid.glue "$@" -vv
+python3 -m polar2grid.glue -vv "$@"

--- a/swbundle/polar2grid.sh
+++ b/swbundle/polar2grid.sh
@@ -39,4 +39,4 @@ export OMP_NUM_THREADS=${OMP_NUM_THREADS:-2}
 # Call the python module to do the processing, passing all arguments
 export PROG_NAME="polar2grid.sh"
 export USE_POLAR2GRID_DEFAULTS=1
-python3 -m polar2grid.glue "$@" -vv
+python3 -m polar2grid.glue -vv "$@"

--- a/swbundle/search_noaa_s3_viirs.sh
+++ b/swbundle/search_noaa_s3_viirs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+### Verify simple test products with known products ###
+#
+# Copyright (C) 2026 Space Science and Engineering Center (SSEC),
+#  University of Wisconsin-Madison.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file is part of the polar2grid software package. Polar2grid takes
+# satellite observation data, remaps it, and writes it to a file format for
+# input into another program.
+# Documentation: http://www.ssec.wisc.edu/software/polar2grid/
+
+export POLAR2GRID_HOME="$( cd -P "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && cd .. && pwd )"
+
+# Setup necessary environments
+# __SWBUNDLE_ENVIRONMENT_INJECTION__
+
+# Run tests for each test data directory in the base directory
+python3 -m polar2grid.utils.search_noaa_s3_viirs "$@"


### PR DESCRIPTION
This PR adds a new utility script called `search_noaa_s3_viirs.sh` which allows the user to specify the satellite, bands, and start/end time that they wish to pull from NOAA's AWS S3 buckets. Satellite can be snpp, n20, or n21. The way this works is:

1. Iterate over hour between start and end, keeping in mind that we want the granule to cover these times and may need to search earlier than start time to find a granule.
2. For each hour, generate a glob pattern for S3.
3. Glob the S3 bucket.
4. For each result, do a finer grained search on the time of that file to make sure it over laps with the times we're concerned about.

My script includes an optimization using the `s3fs` library. Instead of using `glob` directly it uses the "find" functionality to search for all objects under a path that match a particular "prefix". For many glob patterns (times or bands) this proves to be much faster. The regular `glob` functionality requires listing and searching through all objects in the bucket.

This example call should work:

```bash
polar2grid.sh -r viirs_sdr -w geotiff -vvv -f @<(search_noaa_s3_viirs.sh -s n20 -b I04 -b GITCO --start-time 2026-04-23T12:00:00 --end-time 2026-04-23T12:01:00)
```

You can also specify `-b ALL` to do all bands and geolocation files. Note NOAA buckets don't have up to date non-terrain corrected files.