### PR TITLE
Add new --filter-negative-so2 flag 

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,7 +16,7 @@ import os
 import sys
 import urllib.request
 import warnings
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from shutil import copyfileobj
 
 import yaml

--- a/doc/source/readers/omps_edr.rst
+++ b/doc/source/readers/omps_edr.rst
@@ -23,7 +23,9 @@ Examples:
 
     polar2grid.sh -r omps_edr -w geotiff -f /omps/edr/
 
-    polar2grid.sh -r omps_edr -w geotiff -p ColumnAmountO3 --filter-o3 -f ../omps/V8TOZ-EDR_v4r3_j01_*.nc
+    polar2grid.sh -r omps_edr -w geotiff -p ColumnAmountO3 --filter-by-error-flag -f ../omps/V8TOZ-EDR_v4r3_j01_*.nc
+
+    polar2grid.sh -r omps_edr -w geotiff -p s_ColumnamountSO2_PBL --no-filter-negative-so2 -f ../omps/V8TOS-EDR_v4r5_j02_*.nc
 
     polar2grid.sh -r omps_edr -w geotiff -p AerosolIndex Reflectivity331 -g lcc_fit -f ../omps/*.nc
 

--- a/polar2grid/_glue_argparser.py
+++ b/polar2grid/_glue_argparser.py
@@ -26,8 +26,8 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from glob import glob
 from collections.abc import Callable
+from glob import glob
 
 from polar2grid.core.script_utils import ExtendAction
 from polar2grid.utils.dynamic_imports import get_reader_attr, get_writer_attr

--- a/polar2grid/enhancements/viirs.py
+++ b/polar2grid/enhancements/viirs.py
@@ -22,8 +22,8 @@
 """Enhancement functions for VIIRS."""
 
 import numpy as np
-from trollimage.xrimage import XRImage
 from satpy.enhancements.wrappers import using_map_blocks
+from trollimage.xrimage import XRImage
 
 
 def cloud_layers_lmh(img: XRImage) -> XRImage:

--- a/polar2grid/readers/abi_l2_nc.py
+++ b/polar2grid/readers/abi_l2_nc.py
@@ -74,8 +74,8 @@ from __future__ import annotations
 
 from argparse import ArgumentParser, _ArgumentGroup
 
-from ._base import ReaderProxyBase
 from ..core.script_utils import BooleanFilterAction
+from ._base import ReaderProxyBase
 
 PREFERRED_CHUNK_SIZE: int = 1356
 

--- a/polar2grid/readers/acspo.py
+++ b/polar2grid/readers/acspo.py
@@ -44,8 +44,8 @@ from argparse import ArgumentParser, _ArgumentGroup
 
 from satpy import DataQuery
 
-from ._base import ReaderProxyBase
 from ..core.script_utils import BooleanFilterAction
+from ._base import ReaderProxyBase
 
 DEFAULT_PRODUCTS = ["sst"]
 PREFERRED_CHUNK_SIZE = 2048

--- a/polar2grid/readers/amsr2_l2_gaasp.py
+++ b/polar2grid/readers/amsr2_l2_gaasp.py
@@ -49,7 +49,7 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup, BooleanOptionalAction
+from argparse import ArgumentParser, BooleanOptionalAction, _ArgumentGroup
 
 from satpy import DataQuery
 

--- a/polar2grid/readers/avhrr_l1b_aapp.py
+++ b/polar2grid/readers/avhrr_l1b_aapp.py
@@ -51,13 +51,13 @@ The AVHRR reader provides the following products:
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
 import logging
+from argparse import ArgumentParser, _ArgumentGroup
 
 from satpy import DataQuery, Scene
 
-from ._base import ReaderProxyBase
 from ..core.script_utils import ExtendConstAction
+from ._base import ReaderProxyBase
 
 logger = logging.getLogger(__name__)
 

--- a/polar2grid/readers/aws1_mwr_l1b_nc.py
+++ b/polar2grid/readers/aws1_mwr_l1b_nc.py
@@ -77,8 +77,8 @@ The MWR reader provides the following products:
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
 import logging
+from argparse import ArgumentParser, _ArgumentGroup
 
 from satpy import DataQuery, Scene
 

--- a/polar2grid/readers/mersi2_l1b.py
+++ b/polar2grid/readers/mersi2_l1b.py
@@ -96,13 +96,13 @@ the ``mersi2_l1b`` frontend name. The MERSI2 frontend provides the following pro
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
 import logging
+from argparse import ArgumentParser, _ArgumentGroup
 
-from satpy import Scene, DataQuery
+from satpy import DataQuery, Scene
 
-from ._base import ReaderProxyBase
 from ..core.script_utils import ExtendConstAction
+from ._base import ReaderProxyBase
 
 logger = logging.getLogger(__name__)
 

--- a/polar2grid/readers/mirs.py
+++ b/polar2grid/readers/mirs.py
@@ -175,7 +175,7 @@ As an example, the ATMS band options are:
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup, BooleanOptionalAction
+from argparse import ArgumentParser, BooleanOptionalAction, _ArgumentGroup
 
 from satpy import DataID, Scene
 

--- a/polar2grid/readers/modis_l1b.py
+++ b/polar2grid/readers/modis_l1b.py
@@ -135,8 +135,8 @@ angle is less than 90 degrees.
 from __future__ import annotations
 
 import argparse
-from argparse import ArgumentParser, _ArgumentGroup
 import logging
+from argparse import ArgumentParser, _ArgumentGroup
 
 from satpy import DataQuery, Scene
 

--- a/polar2grid/readers/mws_l1b_nc.py
+++ b/polar2grid/readers/mws_l1b_nc.py
@@ -92,8 +92,8 @@ The MWS reader provides the following products:
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
 import logging
+from argparse import ArgumentParser, _ArgumentGroup
 
 from ._base import ReaderProxyBase
 

--- a/polar2grid/readers/omps_edr.py
+++ b/polar2grid/readers/omps_edr.py
@@ -62,19 +62,24 @@ name prefix. Some products are available from both files.
 | s_STLO3               | Corrected total O3 by assuming SO2 located in 15-19km layer |
 +-----------------------+-------------------------------------------------------------+
 
-The ``--filter-o3`` flag described below applies only to the total column
-ozone products.
+The ``--filter-by-error-flag`` flag described below applies to every product
+loaded from a file, as both the total column ozone and the sulfur dioxide files
+contain the ``ErrorFlag`` variable. It is off by default.
+
+The ``--filter-negative-so2`` flag applies only to the SO2 column amount
+products (``s_ColumnamountSO2_*``). Unlike the above, it is on by default;
+use ``--no-filter-negative-so2`` to keep the negative retrieval values.
 
 """
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup
+from argparse import ArgumentParser, BooleanOptionalAction, _ArgumentGroup
 
 from satpy import DataQuery
 
-from ._base import ReaderProxyBase
 from ..core.script_utils import BooleanFilterAction
+from ._base import ReaderProxyBase
 
 PREFERRED_CHUNK_SIZE: int = 6400
 
@@ -131,15 +136,24 @@ def add_reader_argument_groups(
         group = parser.add_argument_group(title="OMPS EDR Reader")
 
     group.add_argument(
-        "--filter-o3",
+        "--filter-by-error-flag",
         action=BooleanFilterAction,
         dest="filter_by_error_flag",
         default=[],
         const=[0, 1],
-        help="Filter total ozone products by the 'ErrorFlag' variable. "
+        help="Filter ozone and SO2 products by the 'ErrorFlag' variable. "
         "When enabled valid pixels are those where "
-        "'ErrorFlag' is 0 or 1. Defaults to off. Specify '--filter-o3' to "
+        "'ErrorFlag' is 0 or 1. Defaults to off. Specify '--filter-by-error-flag' to "
         "enable filtering.",
+    )
+    group.add_argument(
+        "--filter-negative-so2",
+        action=BooleanOptionalAction,
+        default=True,
+        dest="filter_negative_so2",
+        help="Remove negative values from the SO2 column amount products "
+        "('s_ColumnamountSO2_*'). This is on by default, specify "
+        "'--no-filter-negative-so2' to disable it.",
     )
 
     return group, None

--- a/polar2grid/readers/viirs_edr.py
+++ b/polar2grid/readers/viirs_edr.py
@@ -99,7 +99,7 @@ Averaging resampling. The ``--weight-delta-max`` parameter set to 40 and the
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup, BooleanOptionalAction
+from argparse import ArgumentParser, BooleanOptionalAction, _ArgumentGroup
 
 from satpy import DataQuery
 

--- a/polar2grid/resample/resample_decisions.py
+++ b/polar2grid/resample/resample_decisions.py
@@ -33,8 +33,8 @@ try:
 except ImportError:
     from satpy.writers import DecisionTree
 
-from polar2grid.utils.legacy_compat import get_sensor_alias
 from polar2grid.utils.config import recursive_dict_update
+from polar2grid.utils.legacy_compat import get_sensor_alias
 
 logger = logging.getLogger(__name__)
 

--- a/polar2grid/tests/test_resample/test_resample_scene.py
+++ b/polar2grid/tests/test_resample/test_resample_scene.py
@@ -31,7 +31,6 @@ from pytest_lazy_fixtures import lf as lazy_fixture
 from satpy import Scene
 from satpy.resample.kdtree import KDTreeResampler
 from satpy.resample.native import NativeResampler
-
 from satpy.tests.utils import CustomScheduler
 
 from polar2grid.resample._resample_scene import resample_scene

--- a/polar2grid/utils/create_awips_debug_tiles.py
+++ b/polar2grid/utils/create_awips_debug_tiles.py
@@ -25,7 +25,7 @@ import contextlib
 import os
 import sys
 import tempfile
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 import dask.array as da
 import numpy as np

--- a/polar2grid/utils/legacy_compat.py
+++ b/polar2grid/utils/legacy_compat.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Generator, Iterable
 
-from satpy import DataID, DataQuery, Scene, DatasetDict
+from satpy import DataID, DataQuery, DatasetDict, Scene
 
 logger = logging.getLogger(__name__)
 

--- a/polar2grid/utils/search_noaa_s3_viirs.py
+++ b/polar2grid/utils/search_noaa_s3_viirs.py
@@ -19,12 +19,12 @@ Example usage:
 from __future__ import annotations
 
 import argparse
-from glob import fnmatch
 import os
 import re
 import sys
 from collections.abc import Iterable, Iterator
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
+from glob import fnmatch
 
 import s3fs
 

--- a/polar2grid/writers/binary.py
+++ b/polar2grid/writers/binary.py
@@ -46,8 +46,8 @@ import logging
 import dask.array as da
 import numpy as np
 import xarray as xr
-from satpy.writers.core.image import ImageWriter
 from satpy.enhancements.enhancer import get_enhanced_image
+from satpy.writers.core.image import ImageWriter
 
 from polar2grid.core.dtype import NUMPY_DTYPE_STRS, clip_to_data_type, dtype_to_str, int_or_float, str_to_dtype
 from polar2grid.core.script_utils import NumpyDtypeList

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ line-length = 120
 
 [tool.ruff.lint]
 # See https://docs.astral.sh/ruff/rules/
-select = ["E", "W", "B", "D", "T10", "C90", "UP"]
+select = ["E", "W", "B", "D", "I", "T10", "C90", "UP"]
 # Remove D416 when all docstrings have been converted to google-style
 # UP031/UP032 (%-format and .format() -> f-string) are deferred: ~73 sites, and the
 # %-formatting in logging calls must stay lazy. Handle them in a separate pass.


### PR DESCRIPTION
Also rename `--filter-o3` flag to `--filter-by-error-flag`.

The new flag is on by default, error flag flag is still off by default.

Should close #820 but we could also wait for @kathys to have time to test it more thoroughly. This PR depends on https://github.com/pytroll/satpy/pull/3455 being merged first for the new keyword argument to be available.