### PR TITLE
Use preferred "METimage" spelling in user-facing text

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,7 +4,7 @@ Release Notes
 Version 3.3.0 (unreleased)
 --------------------------
 
-* New Metop-SG MetImage (VII) Level 1b reader.
+* New Metop-SG METimage (VII) Level 1b reader.
 * New Metop-SG MicroWave Sounder (MWS) reader.
 
 Version 3.2.0 (2026-03-02)

--- a/doc/source/summary_table.rst
+++ b/doc/source/summary_table.rst
@@ -87,7 +87,7 @@
       - Binary
       - avhrr_l1b
       - binary
-    * - **Metop-SGA1 METimage (VII) Level 1b**
+    * - **Metop-SG METimage (VII) Level 1b**
       - W_XX-EUMETSAT-Darmstadt,SAT,SGA1-VII-1B-RAD\*.nc
       - 8 bit single band GeoTIFF
       - metimage_l1b_nc


### PR DESCRIPTION
The METImage instrument on Metop-SG is preferred to be written as "METimage". The NEWS.rst entry for the new reader was the only place using a different spelling ("MetImage").

Also drop the "A1" suffix from the summary table entry so it uses the generic "Metop-SG" platform name, matching NEWS.rst.

The lowercase "metimage" occurrences elsewhere are identifiers -- the Satpy reader name, the module and documentation filenames, and the "sensor: metimage" match key in resampling.yaml -- and are left alone.